### PR TITLE
Fix struct names used for the params by azure_devops_query_work_items and azure_devops_query_work_items_wiql

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -412,7 +412,7 @@ struct DownloadAttachmentArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
-struct GetBoardWorkItemsArgs {
+struct QueryWorkItemsArgs {
     /// Azure DevOps organization name
     organization: String,
     /// Azure DevOps project name
@@ -947,7 +947,7 @@ impl AzureMcpServer {
     )]
     async fn azure_devops_query_work_items(
         &self,
-        args: Parameters<GetBoardWorkItemsArgs>,
+        args: Parameters<QueryWorkItemsArgs>,
     ) -> Result<CallToolResult, McpError> {
         log::info!(
             "Tool invoked: azure_devops_query_work_items(area_path={:?}, iteration={:?}, include_board_column={:?}, exclude_state={:?})",


### PR DESCRIPTION
This PR fixes the name of the struct used for the params of the `azure_devops_query_work_items_wiql` tool changing it from `QueryWorkItemsArgs` to `QueryWorkItemsArgsWiql` and renames the one used by the tool `azure_devops_query_work_items` from `GetBoardWorkItemsArgs ` to `QueryWorkItemsArgs`.