### PR TITLE
Exposes Azure DevOps tags via tool

### DIFF
--- a/src/azure/mod.rs
+++ b/src/azure/mod.rs
@@ -4,4 +4,5 @@ pub mod client;
 pub mod models;
 pub mod organizations;
 pub mod projects;
+pub mod tags;
 pub mod work_items;

--- a/src/azure/tags.rs
+++ b/src/azure/tags.rs
@@ -22,10 +22,8 @@ pub async fn list_tags(
     client: &AzureDevOpsClient,
     organization: &str,
     project: &str,
-) -> Result<Vec<String>, AzureError> {
+) -> Result<Vec<TagDefinition>, AzureError> {
     let path = "wit/tags?api-version=7.1";
     let response: TagListResponse = client.get(organization, project, path).await?;
-
-    // Extract just the tag names
-    Ok(response.value.into_iter().map(|tag| tag.name).collect())
+    Ok(response.value)
 }

--- a/src/azure/tags.rs
+++ b/src/azure/tags.rs
@@ -1,0 +1,31 @@
+use crate::azure::client::{AzureDevOpsClient, AzureError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TagDefinition {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(rename = "lastUpdated", default)]
+    pub last_updated: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TagListResponse {
+    pub count: u32,
+    pub value: Vec<TagDefinition>,
+}
+
+/// Get all tags in a project
+pub async fn list_tags(
+    client: &AzureDevOpsClient,
+    organization: &str,
+    project: &str,
+) -> Result<Vec<String>, AzureError> {
+    let path = "wit/tags?api-version=7.1";
+    let response: TagListResponse = client.get(organization, project, path).await?;
+
+    // Extract just the tag names
+    Ok(response.value.into_iter().map(|tag| tag.name).collect())
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -711,13 +711,16 @@ impl AzureMcpServer {
         args: Parameters<ListTagsArgs>,
     ) -> Result<CallToolResult, McpError> {
         log::info!("Tool invoked: azure_devops_list_tags");
-        let tag_names = tags::list_tags(&self.client, &args.0.organization, &args.0.project)
+        let tags = tags::list_tags(&self.client, &args.0.organization, &args.0.project)
             .await
             .map_err(|e| McpError {
                 code: ErrorCode(-32000),
                 message: e.to_string().into(),
                 data: None,
             })?;
+
+        // Extract just the tag names for compact response
+        let tag_names: Vec<String> = tags.into_iter().map(|tag| tag.name).collect();
 
         Ok(CallToolResult::success(vec![Content::text(
             compact_llm::to_compact_string(&tag_names).unwrap(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,5 @@
 use crate::azure::client::AzureDevOpsClient;
-use crate::azure::{boards, organizations, projects, work_items};
+use crate::azure::{boards, organizations, projects, tags, work_items};
 use crate::compact_llm;
 use rmcp::{
     ErrorData as McpError,
@@ -163,6 +163,16 @@ struct ListProjectsArgs {
 
 #[derive(Deserialize, JsonSchema)]
 struct ListWorkItemTypesArgs {
+    /// Azure DevOps organization name (required, non-empty). Use azure_devops_list_organizations to get available organizations.
+    #[serde(deserialize_with = "deserialize_non_empty_string")]
+    organization: String,
+    /// Azure DevOps project name (required, non-empty). Use azure_devops_list_projects to get available projects.
+    #[serde(deserialize_with = "deserialize_non_empty_string")]
+    project: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct ListTagsArgs {
     /// Azure DevOps organization name (required, non-empty). Use azure_devops_list_organizations to get available organizations.
     #[serde(deserialize_with = "deserialize_non_empty_string")]
     organization: String,
@@ -692,6 +702,25 @@ impl AzureMcpServer {
 
         Ok(CallToolResult::success(vec![Content::text(
             compact_llm::to_compact_string(&types).unwrap(),
+        )]))
+    }
+
+    #[tool(description = "List all tags in use in the project")]
+    async fn azure_devops_list_tags(
+        &self,
+        args: Parameters<ListTagsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        log::info!("Tool invoked: azure_devops_list_tags");
+        let tag_names = tags::list_tags(&self.client, &args.0.organization, &args.0.project)
+            .await
+            .map_err(|e| McpError {
+                code: ErrorCode(-32000),
+                message: e.to_string().into(),
+                data: None,
+            })?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            compact_llm::to_compact_string(&tag_names).unwrap(),
         )]))
     }
 


### PR DESCRIPTION
Adds a tool to list tags from Azure DevOps.

This change introduces a new module for handling tags and exposes it as a tool, enabling users to retrieve tags from Azure DevOps projects.