### PR TITLE
Reduces token usage in list responses

### DIFF
--- a/src/azure/organizations.rs
+++ b/src/azure/organizations.rs
@@ -40,10 +40,16 @@ pub async fn get_profile(client: &AzureDevOpsClient) -> Result<Profile, AzureErr
 pub async fn list_organizations(
     client: &AzureDevOpsClient,
     member_id: &str,
-) -> Result<Vec<Organization>, AzureError> {
+) -> Result<Vec<String>, AzureError> {
     let path = format!("accounts?memberId={}&api-version=7.1", member_id);
     let response: OrganizationListResponse = client
         .vssps_request(Method::GET, &path, None::<&String>)
         .await?;
-    Ok(response.value)
+
+    // Extract just the organization names
+    Ok(response
+        .value
+        .into_iter()
+        .map(|org| org.account_name)
+        .collect())
 }

--- a/src/azure/projects.rs
+++ b/src/azure/projects.rs
@@ -23,10 +23,16 @@ pub struct ProjectListResponse {
 pub async fn list_projects(
     client: &AzureDevOpsClient,
     organization: &str,
-) -> Result<Vec<Project>, AzureError> {
+) -> Result<Vec<String>, AzureError> {
     let path = "projects?api-version=7.1";
     let response: ProjectListResponse = client
         .org_request(organization, Method::GET, path, None::<&String>)
         .await?;
-    Ok(response.value)
+
+    // Extract just the project names
+    Ok(response
+        .value
+        .into_iter()
+        .map(|project| project.name)
+        .collect())
 }


### PR DESCRIPTION
Compacts the responses provided by the list organization and list projects tools to reduce the token usage.

Instead of returning the full `Organization` and `Project` structs, the API now returns only the organization and project names, respectively.