### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-for-azure-devops-boards"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "mcp-tools-codegen"]
 
 [package]
 name = "mcp-for-azure-devops-boards"
-version = "0.5.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Daniele Salvatore Albano <d.albano@gmail.com>"]
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL com.github.actions.name="auto publish"
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="blue"
 
-LABEL version="0.5.0"
+LABEL version="0.7.0"
 LABEL repository="https://github.com/danielealbano/mcp-for-azure-devops-boards"
 LABEL homepage="https://github.com/danielealbano/mcp-for-azure-devops-boards"
 LABEL maintainer="Daniele Salvatore Albano <d.albano@gmail.com>"


### PR DESCRIPTION
## Summary
- Bumps version from 0.5.0 to 0.7.0 in `Cargo.toml` and `Dockerfile` for the 0.7 release.

## Changes
- `Cargo.toml`: `version = "0.5.0"` → `version = "0.7.0"`
- `Dockerfile`: `LABEL version="0.5.0"` → `LABEL version="0.7.0"`
- `Cargo.lock`: Updated automatically