### PR TITLE
Add --install CLI flag for MCP client auto-registration

### DIFF
--- a/.github/workflows/ci-pr-build-and-test.yml
+++ b/.github/workflows/ci-pr-build-and-test.yml
@@ -46,6 +46,22 @@ jobs:
       - name: Test
         run: cargo test --release --locked --all-features
 
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build E2E Docker images
+        run: make test-e2e-build
+
+      - name: Run E2E tests
+        run: cargo test --features test-support --locked --ignored
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-build-and-test.yml
+++ b/.github/workflows/ci-pr-build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo clippy --features test-support --locked -- -D warnings
 
       - name: Test
-        run: cargo test --release --locked --all-features
+        run: cargo test --release --locked --features test-support
 
   e2e-tests:
     name: E2E Tests
@@ -60,7 +60,7 @@ jobs:
         run: make test-e2e-build
 
       - name: Run E2E tests
-        run: cargo test --features test-support --locked --ignored
+        run: cargo test --features test-support,e2e-tests --locked
 
   security-audit:
     name: Security Audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +112,28 @@ dependencies = [
  "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -120,6 +158,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "azure_core"
@@ -205,6 +286,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
 ]
 
 [[package]]
@@ -321,6 +476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +593,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +622,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -455,6 +652,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -491,6 +694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -535,6 +748,28 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ferroid"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+dependencies = [
+ "portable-atomic",
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -750,7 +985,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -769,12 +1004,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -793,6 +1034,21 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html2text"
@@ -954,6 +1210,51 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -976,10 +1277,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
@@ -1119,12 +1440,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1166,6 +1500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1535,18 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1238,6 +1593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "mcp-for-azure-devops-boards"
 version = "0.7.0"
 dependencies = [
@@ -1248,6 +1609,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "csv",
+ "dirs",
  "dotenv",
  "env_logger",
  "futures",
@@ -1265,8 +1627,11 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "tempfile",
+ "testcontainers",
  "thiserror 1.0.69",
  "tokio",
+ "toml",
  "tower",
  "urlencoding",
 ]
@@ -1349,10 +1714,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1364,10 +1729,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1451,6 +1880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1896,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -1486,9 +1927,34 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -1581,6 +2047,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +2121,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1770,6 +2280,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,7 +2377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1859,6 +2389,20 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1905,6 +2449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,12 +2477,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.6.0",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1964,6 +2561,18 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
  "serde",
  "serde_json",
 ]
@@ -2019,7 +2628,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2027,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2118,6 +2740,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2769,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.12.1",
+ "schemars 0.9.0",
+ "schemars 1.1.0",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2244,6 +2917,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2961,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -2278,7 +2986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2330,6 +3038,37 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "ferroid",
+ "futures",
+ "http 1.3.1",
+ "itertools",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
 
 [[package]]
 name = "thiserror"
@@ -2454,6 +3193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,13 +3227,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 2.12.1",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2568,6 +3407,39 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -2746,6 +3618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +3640,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +3663,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3048,6 +3952,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3981,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -3132,6 +4055,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"
+testcontainers = "0.27"
 
 [features]
 test-support = ["mockall"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ testcontainers = "0.27"
 
 [features]
 test-support = ["mockall"]
+e2e-tests = []
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,11 @@ regex = "1.11"
 once_cell = "1.20"
 urlencoding = "2.1"
 futures = "0.3"
+dirs = "6"
+toml = "0.8"
 
 [dev-dependencies]
+tempfile = "3"
 
 [features]
 test-support = ["mockall"]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-e2e-build:
 
 # Run E2E testcontainers tests (requires Docker)
 test-e2e: test-e2e-build
-	cargo test --features test-support --ignored
+	cargo test --features test-support,e2e-tests
 
 # Show help
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release run check test lint fmt clean help
+.PHONY: all build release run check test lint fmt clean help test-e2e-build test-e2e
 
 # Default target
 all: fmt lint test build
@@ -35,15 +35,27 @@ fmt:
 clean:
 	cargo clean
 
+# Build Docker images for E2E tests
+test-e2e-build:
+	docker build -t mcp-test-claude-code tests/docker/claude-code/
+	docker build -t mcp-test-cursor tests/docker/cursor/
+	docker build -t mcp-test-gemini-cli tests/docker/gemini-cli/
+
+# Run E2E testcontainers tests (requires Docker)
+test-e2e: test-e2e-build
+	cargo test --features test-support --ignored
+
 # Show help
 help:
 	@echo "Available targets:"
-	@echo "  build   - Build in debug mode"
-	@echo "  release - Build in release mode"
-	@echo "  run     - Run the application (debug mode)"
-	@echo "  check   - Check if the code compiles"
-	@echo "  test    - Run tests"
-	@echo "  lint    - Run clippy for linting"
-	@echo "  fmt     - Format code"
-	@echo "  clean   - Clean build artifacts"
-	@echo "  all     - Run fmt, lint, test, and build"
+	@echo "  build          - Build in debug mode"
+	@echo "  release        - Build in release mode"
+	@echo "  run            - Run the application (debug mode)"
+	@echo "  check          - Check if the code compiles"
+	@echo "  test           - Run tests"
+	@echo "  lint           - Run clippy for linting"
+	@echo "  fmt            - Format code"
+	@echo "  clean          - Clean build artifacts"
+	@echo "  test-e2e-build - Build Docker images for E2E tests"
+	@echo "  test-e2e       - Run E2E testcontainers tests (requires Docker)"
+	@echo "  all            - Run fmt, lint, test, and build"

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ clean:
 
 # Build Docker images for E2E tests
 test-e2e-build:
-	docker build -t mcp-test-claude-code tests/docker/claude-code/
-	docker build -t mcp-test-cursor tests/docker/cursor/
-	docker build -t mcp-test-gemini-cli tests/docker/gemini-cli/
+	docker build --load -t mcp-test-claude-code tests/docker/claude-code/
+	docker build --load -t mcp-test-cursor tests/docker/cursor/
+	docker build --load -t mcp-test-gemini-cli tests/docker/gemini-cli/
 
 # Run E2E testcontainers tests (requires Docker)
 test-e2e: test-e2e-build

--- a/README.md
+++ b/README.md
@@ -102,19 +102,114 @@ path/to/mcp-for-azure-devops-boards --server --port 3000
 
 *Note: Make sure you have run `az login` in your terminal so the process can pick up the credentials.*
 
-#### Claude Desktop
+#### Quick setup with `--install`
 
-Add the following to your `claude_desktop_config.json`:
+The fastest way to register the MCP server with your preferred client:
+
+```bash
+mcp-for-azure-devops-boards --install <target>
+```
+
+Valid targets: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `codex`, `gemini-cli`.
+
+The command auto-detects the binary path, resolves the correct config file location, and writes the entry in the expected format. Existing configuration is preserved.
+
+#### Manual configuration
+
+##### Claude Code
+
+Config file: `~/.claude.json`
 
 ```json
 {
   "mcpServers": {
-    "azure-devops-boards": {
-      "command": "path/to/mcp-for-azure-devops-boards"
+    "mcp-for-azure-devops-boards": {
+      "command": "/opt/homebrew/bin/mcp-for-azure-devops-boards"
     }
   }
 }
 ```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
+
+##### Claude Desktop
+
+Config file locations:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "mcp-for-azure-devops-boards": {
+      "command": "/opt/homebrew/bin/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
+
+##### Cursor
+
+Config file: `~/.cursor/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "mcp-for-azure-devops-boards": {
+      "command": "/opt/homebrew/bin/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
+
+##### VS Code
+
+Config file: `.vscode/mcp.json` (workspace level)
+
+```json
+{
+  "servers": {
+    "mcp-for-azure-devops-boards": {
+      "type": "stdio",
+      "command": "/opt/homebrew/bin/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
+
+##### gemini-cli
+
+Config file: `~/.gemini/settings.json`
+
+```json
+{
+  "mcpServers": {
+    "mcp-for-azure-devops-boards": {
+      "command": "/opt/homebrew/bin/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
+
+##### Codex CLI
+
+Config file: `~/.codex/config.toml`
+
+```toml
+[mcp_servers.mcp-for-azure-devops-boards]
+command = "/opt/homebrew/bin/mcp-for-azure-devops-boards"
+```
+
+> **Windows (Scoop)**: Replace the command path with `%USERPROFILE%\\scoop\\apps\\mcp-for-azure-devops-boards\\current\\mcp-for-azure-devops-boards.exe`.
 
 ### Available Tools
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,11 +30,17 @@ graph LR
 │   ├── test_tools_tags.rs
 │   ├── test_tools_work_item_types.rs
 │   ├── test_tools_classification_nodes.rs
-│   └── test_tools_work_items.rs
+│   ├── test_tools_work_items.rs
+│   ├── test_install_e2e.rs       # E2E testcontainers tests for install config format
+│   ├── docker/                   # Dockerfiles for E2E testcontainers tests
+│   │   ├── claude-code/Dockerfile
+│   │   ├── cursor/Dockerfile
+│   │   └── gemini-cli/Dockerfile
 ├── src/
-│   ├── main.rs                   # CLI entry (clap), transport selection
+│   ├── main.rs                   # CLI entry (clap), transport selection, --install
 │   ├── lib.rs                    # Library root: re-exports modules
 │   ├── compact_llm.rs            # Compact JSON serializer for LLM output
+│   ├── install.rs                # CLI --install: config generation for MCP clients
 │   ├── azure/                    # Azure DevOps API client layer
 │   │   ├── mod.rs
 │   │   ├── client.rs             # AzureDevOpsClient, AzureError, auth, HTTP helpers

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -44,12 +44,16 @@ Cargo workspace with two members:
 | `base64` | 0.22 | Base64 encoding |
 | `urlencoding` | 2.1 | URL encoding |
 | `dotenv` | 0.15 | `.env` file loading |
+| `dirs` | 6 | Cross-platform home/config directory resolution |
+| `toml` | 0.8 | TOML serialization / deserialization (Codex CLI config) |
 
 ### Dev
 
 | Crate | Version | Purpose |
 |---|---|---|
 | `mockall` | 0.12 (optional, via `test-support` feature) | Trait-based test mocking for `MockAzureDevOpsApi`; required for integration tests |
+| `tempfile` | 3 | Temporary files and directories for unit tests |
+| `testcontainers` | 0.27 | Docker-based E2E tests for install config verification |
 
 ### Codegen Crate (`mcp-tools-codegen`)
 
@@ -67,6 +71,7 @@ All configuration via CLI flags (clap):
 |---|---|---|
 | `--server` | false | Run in HTTP server mode (default: stdio) |
 | `--port` | 3000 | HTTP server port (only with `--server`) |
+| `--install` | — | Install MCP server configuration for the specified client (claude-code, claude-desktop, cursor, vscode, codex, gemini-cli) |
 
 Environment variables:
 - `RUST_LOG` — controls log level (e.g. `RUST_LOG=debug`)

--- a/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
+++ b/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
@@ -12,16 +12,16 @@ Allow users to register the MCP server with their preferred AI client via a sing
 
 ### Acceptance Criteria
 
-- [ ] `--install <target>` flag added (targets: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `codex`, `gemini-cli`)
-- [ ] Detects binary path via `std::env::current_exe()`
-- [ ] Resolves config file path per target and platform
-- [ ] Creates/updates config file with correct format per target
-- [ ] Mutually exclusive with `--server`
-- [ ] Preserves existing config file content (other keys, other server entries)
-- [ ] Updates existing server entry if already present (path changed)
-- [ ] Creates parent directories if they don't exist
-- [ ] Prints success message with config file path and exits
-- [ ] Unit tests for all targets and edge cases
+- [x] `--install <target>` flag added (targets: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `codex`, `gemini-cli`)
+- [x] Detects binary path via `std::env::current_exe()`
+- [x] Resolves config file path per target and platform
+- [x] Creates/updates config file with correct format per target
+- [x] Mutually exclusive with `--server`
+- [x] Preserves existing config file content (other keys, other server entries)
+- [x] Updates existing server entry if already present (path changed)
+- [x] Creates parent directories if they don't exist
+- [x] Prints success message with config file path and exits
+- [x] Unit tests for all targets and edge cases
 
 ---
 
@@ -44,8 +44,8 @@ tempfile = "3"
 
 **Definition of Done**:
 
-- [ ] `dirs`, `toml` added to `[dependencies]`
-- [ ] `tempfile` added to `[dev-dependencies]`
+- [x] `dirs`, `toml` added to `[dependencies]`
+- [x] `tempfile` added to `[dev-dependencies]`
 
 ---
 
@@ -176,15 +176,15 @@ command = "/path/to/mcp-for-azure-devops-boards"
 
 **Definition of Done**:
 
-- [ ] Module compiles without warnings
-- [ ] All 6 targets supported with correct format
-- [ ] JSON targets use correct key (`mcpServers` vs `servers`)
-- [ ] VS Code entries include `"type": "stdio"`
-- [ ] Codex uses TOML format
-- [ ] Parent directories created when needed
-- [ ] Existing config content preserved
-- [ ] Existing server entry updated on re-install
-- [ ] Error variants cover all failure modes (including `InvalidConfigFormat` for non-Object JSON root)
+- [x] Module compiles without warnings
+- [x] All 6 targets supported with correct format
+- [x] JSON targets use correct key (`mcpServers` vs `servers`)
+- [x] VS Code entries include `"type": "stdio"`
+- [x] Codex uses TOML format
+- [x] Parent directories created when needed
+- [x] Existing config content preserved
+- [x] Existing server entry updated on re-install
+- [x] Error variants cover all failure modes (including `InvalidConfigFormat` for non-Object JSON root)
 
 ---
 
@@ -194,7 +194,7 @@ command = "/path/to/mcp-for-azure-devops-boards"
 
 **Definition of Done**:
 
-- [ ] Module accessible from `main.rs` and integration tests
+- [x] Module accessible from `main.rs` and integration tests
 
 ---
 
@@ -231,10 +231,10 @@ if let Some(target) = &args.install {
 
 **Definition of Done**:
 
-- [ ] `--install <target>` flag accepted by CLI
-- [ ] Conflicts with `--server` (clap error if both provided)
-- [ ] Process exits after successful install with message
-- [ ] Error propagated correctly on failure
+- [x] `--install <target>` flag accepted by CLI
+- [x] Conflicts with `--server` (clap error if both provided)
+- [x] Process exits after successful install with message
+- [x] Error propagated correctly on failure
 
 ---
 
@@ -282,9 +282,9 @@ if let Some(target) = &args.install {
 
 **Definition of Done**:
 
-- [ ] All 6 targets have config creation tests
-- [ ] Edge cases covered (existing config, re-install, directory creation, malformed input, empty files)
-- [ ] Path resolution tested for all targets (suffix assertions)
+- [x] All 6 targets have config creation tests
+- [x] Edge cases covered (existing config, re-install, directory creation, malformed input, empty files)
+- [x] Path resolution tested for all targets (suffix assertions)
 
 ---
 

--- a/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
+++ b/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
@@ -518,51 +518,51 @@ Verify the entire implementation end-to-end to ensure all quality gates pass and
 
 ### Acceptance Criteria
 
-- [ ] All quality gates pass (`make fmt`, `make lint`, `make test`, `make build`)
-- [ ] All install targets produce correct output
-- [ ] E2E Docker images build and tests pass
-- [ ] Documentation updated and accurate
-- [ ] No code quality issues
+- [x] All quality gates pass (`make fmt`, `make lint`, `make test`, `make build`)
+- [x] All install targets produce correct output
+- [x] E2E Docker images build and tests pass
+- [x] Documentation updated and accurate
+- [x] No code quality issues
 
 ### Task 4.1: End-to-end verification of entire implementation
 
 #### Build and quality gates
 
-- [ ] `make fmt` passes (no formatting issues)
-- [ ] `make lint` passes (no clippy warnings)
-- [ ] `make test` passes (all unit + integration tests)
-- [ ] `make build` passes (no build warnings)
+- [x] `make fmt` passes (no formatting issues)
+- [x] `make lint` passes (no clippy warnings)
+- [x] `make test` passes (all unit + integration tests)
+- [x] `make build` passes (no build warnings)
 
 #### Install flag behavior
 
-- [ ] `--install claude-code` produces correct JSON at `~/.claude.json` with `mcpServers` key
-- [ ] `--install claude-desktop` produces correct JSON at `<config_dir>/Claude/claude_desktop_config.json` with `mcpServers` key
-- [ ] `--install cursor` produces correct JSON at `~/.cursor/mcp.json` with `mcpServers` key
-- [ ] `--install vscode` produces correct JSON at `.vscode/mcp.json` with `servers` key and `"type": "stdio"`
-- [ ] `--install gemini-cli` produces correct JSON at `~/.gemini/settings.json` with `mcpServers` key
-- [ ] `--install codex` produces correct TOML at `~/.codex/config.toml` with `[mcp_servers.mcp-for-azure-devops-boards]`
-- [ ] `--install` and `--server` together are rejected by clap
-- [ ] `--install` with invalid target is rejected by clap
-- [ ] Existing config file content is preserved after install
-- [ ] Re-running install updates the binary path
-- [ ] Parent directories are created if missing
+- [x] `--install claude-code` produces correct JSON at `~/.claude.json` with `mcpServers` key
+- [x] `--install claude-desktop` produces correct JSON at `<config_dir>/Claude/claude_desktop_config.json` with `mcpServers` key
+- [x] `--install cursor` produces correct JSON at `~/.cursor/mcp.json` with `mcpServers` key
+- [x] `--install vscode` produces correct JSON at `.vscode/mcp.json` with `servers` key and `"type": "stdio"`
+- [x] `--install gemini-cli` produces correct JSON at `~/.gemini/settings.json` with `mcpServers` key
+- [x] `--install codex` produces correct TOML at `~/.codex/config.toml` with `[mcp_servers.mcp-for-azure-devops-boards]`
+- [x] `--install` and `--server` together are rejected by clap
+- [x] `--install` with invalid target is rejected by clap
+- [x] Existing config file content is preserved after install
+- [x] Re-running install updates the binary path
+- [x] Parent directories are created if missing
 
 #### E2E tests
 
-- [ ] `make test-e2e-build` builds all 3 Docker images without errors
-- [ ] `make test-e2e` runs and all E2E tests pass
+- [x] `make test-e2e-build` builds all 3 Docker images without errors
+- [x] `make test-e2e` runs and all E2E tests pass
 
 #### Documentation
 
-- [ ] README MCP Configuration section covers all 6 targets with correct formats
-- [ ] README mentions `--install` flag
-- [ ] `docs/PROJECT.md` has updated dependencies and CLI flag tables
-- [ ] `docs/ARCHITECTURE.md` has `install.rs` and `tests/docker/` in project structure
+- [x] README MCP Configuration section covers all 6 targets with correct formats
+- [x] README mentions `--install` flag
+- [x] `docs/PROJECT.md` has updated dependencies and CLI flag tables
+- [x] `docs/ARCHITECTURE.md` has `install.rs` and `tests/docker/` in project structure
 
 #### Code quality
 
-- [ ] No TODOs in code
-- [ ] No dead code or commented-out code
-- [ ] No temporary hacks
-- [ ] Error handling covers all failure modes
-- [ ] Success messages are clear and include the config file path
+- [x] No TODOs in code
+- [x] No dead code or commented-out code
+- [x] No temporary hacks
+- [x] Error handling covers all failure modes
+- [x] Success messages are clear and include the config file path

--- a/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
+++ b/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
@@ -1,0 +1,568 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan: CLI `--install` Flag and MCP Client Configuration
+
+---
+
+## User Story 1: CLI `--install` flag with multi-client configuration support
+
+Allow users to register the MCP server with their preferred AI client via a single `--install <target>` command that auto-detects the binary path, resolves the correct config file, and writes the entry in the expected format.
+
+### Acceptance Criteria
+
+- [ ] `--install <target>` flag added (targets: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `codex`, `gemini-cli`)
+- [ ] Detects binary path via `std::env::current_exe()`
+- [ ] Resolves config file path per target and platform
+- [ ] Creates/updates config file with correct format per target
+- [ ] Mutually exclusive with `--server`
+- [ ] Preserves existing config file content (other keys, other server entries)
+- [ ] Updates existing server entry if already present (path changed)
+- [ ] Creates parent directories if they don't exist
+- [ ] Prints success message with config file path and exits
+- [ ] Unit tests for all targets and edge cases
+
+---
+
+### Task 1.1: Add runtime dependencies
+
+**Action**: Modify `Cargo.toml`
+
+Add to `[dependencies]`:
+
+```toml
+dirs = "6"
+toml = "0.8"
+```
+
+Add to `[dev-dependencies]`:
+
+```toml
+tempfile = "3"
+```
+
+**Definition of Done**:
+
+- [ ] `dirs`, `toml` added to `[dependencies]`
+- [ ] `tempfile` added to `[dev-dependencies]`
+
+---
+
+### Task 1.2: Create install module
+
+**Action**: Create `src/install.rs`
+
+#### `InstallError` enum
+
+Uses `thiserror`. Variants:
+
+| Variant | Fields | Message |
+|---------|--------|---------|
+| `HomeDirectoryNotFound` | — | `Could not determine home directory` |
+| `ConfigDirectoryNotFound` | — | `Could not determine config directory` |
+| `CurrentDirectoryNotFound` | `source: std::io::Error` | `Could not determine current directory: {source}` |
+| `BinaryPathDetection` | `source: std::io::Error` | `Could not detect binary path: {source}` |
+| `CreateDirectory` | `path: PathBuf, source: std::io::Error` | `Failed to create directory {path}: {source}` |
+| `ReadConfig` | `path: PathBuf, source: std::io::Error` | `Failed to read config file {path}: {source}` |
+| `WriteConfig` | `path: PathBuf, source: std::io::Error` | `Failed to write config file {path}: {source}` |
+| `ParseJson` | `path: PathBuf, source: serde_json::Error` | `Failed to parse JSON config {path}: {source}` |
+| `ParseToml` | `path: PathBuf, source: toml::de::Error` | `Failed to parse TOML config {path}: {source}` |
+| `SerializeToml` | `source: toml::ser::Error` | `Failed to serialize TOML config: {source}` |
+| `InvalidConfigFormat` | `path: PathBuf, detail: String` | `Invalid config format in {path}: {detail}` |
+
+#### `InstallTarget` enum
+
+Derives `Clone`, `Debug`, `clap::ValueEnum`.
+
+| Variant | CLI value | Display |
+|---------|-----------|---------|
+| `ClaudeCode` | `claude-code` | `Claude Code` |
+| `ClaudeDesktop` | `claude-desktop` | `Claude Desktop` |
+| `Cursor` | `cursor` | `Cursor` |
+| `Vscode` | `vscode` | `VS Code` |
+| `Codex` | `codex` | `Codex CLI` |
+| `GeminiCli` | `gemini-cli` | `gemini-cli` |
+
+Implement `std::fmt::Display` for user-facing success messages.
+
+#### Constants
+
+```rust
+const SERVER_NAME: &str = "mcp-for-azure-devops-boards";
+```
+
+#### `resolve_config_path(target: &InstallTarget) -> Result<PathBuf, InstallError>`
+
+| Target | Resolution |
+|--------|-----------|
+| `ClaudeCode` | `dirs::home_dir()? / ".claude.json"` |
+| `Cursor` | `dirs::home_dir()? / ".cursor" / "mcp.json"` |
+| `GeminiCli` | `dirs::home_dir()? / ".gemini" / "settings.json"` |
+| `Codex` | `dirs::home_dir()? / ".codex" / "config.toml"` |
+| `Vscode` | `std::env::current_dir()? / ".vscode" / "mcp.json"` |
+| `ClaudeDesktop` | `dirs::config_dir()? / "Claude" / "claude_desktop_config.json"` |
+
+Note: `dirs::config_dir()` resolves platform-correctly:
+- macOS: `~/Library/Application Support`
+- Linux: `~/.config`
+- Windows: `%APPDATA%`
+
+#### `install(target: &InstallTarget, config_path: &Path, binary_path: &Path) -> Result<String, InstallError>`
+
+1. Create parent directories of `config_path` if they don't exist (`std::fs::create_dir_all`)
+2. Dispatch to format-specific function based on target:
+   - `Codex` → `install_toml(config_path, binary_path)`
+   - `Vscode` → `install_json(config_path, binary_path, "servers", true)`
+   - All others → `install_json(config_path, binary_path, "mcpServers", false)`
+3. Return success message: `"Installed {target} configuration at {config_path}"`
+
+#### `install_json(config_path: &Path, binary_path: &Path, servers_key: &str, include_type_stdio: bool) -> Result<(), InstallError>`
+
+1. Read existing file content. If file doesn't exist OR is empty (0 bytes), use `"{}"` as default. Distinguish "not found" from other IO errors.
+2. Parse as `serde_json::Value`. If the root value is not a JSON Object, return `InstallError::InvalidConfigFormat` with detail `"expected JSON object at root"`.
+3. Ensure `servers_key` exists as an Object (create if missing)
+4. Build server entry as `serde_json::Value`:
+   - If `include_type_stdio`: `{ "type": "stdio", "command": "<binary_path>" }`
+   - Else: `{ "command": "<binary_path>" }`
+   - Convert `binary_path` to string using `to_string_lossy()` for JSON string values
+5. Insert/overwrite entry at key `SERVER_NAME`
+6. Serialize with `serde_json::to_string_pretty`
+7. Write to `config_path` (append trailing newline)
+
+#### `install_toml(config_path: &Path, binary_path: &Path) -> Result<(), InstallError>`
+
+1. Read existing file content. If file doesn't exist OR is empty (0 bytes), use `""` as default.
+2. Parse as `toml::Value::Table`. Convert `binary_path` to string using `to_string_lossy()` for TOML string values.
+3. Ensure `mcp_servers` exists as a Table (create if missing)
+4. Build server entry as `toml::Value::Table` with key `command` = `binary_path` string
+5. Insert/overwrite entry at key `SERVER_NAME`
+6. Serialize with `toml::to_string_pretty`
+7. Write to `config_path`
+
+#### Expected output formats
+
+**Claude Code** (`~/.claude.json`), **Claude Desktop** (`<config_dir>/Claude/claude_desktop_config.json`), **Cursor** (`~/.cursor/mcp.json`), **gemini-cli** (`~/.gemini/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "mcp-for-azure-devops-boards": {
+      "command": "/path/to/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+**VS Code** (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "mcp-for-azure-devops-boards": {
+      "type": "stdio",
+      "command": "/path/to/mcp-for-azure-devops-boards"
+    }
+  }
+}
+```
+
+**Codex CLI** (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.mcp-for-azure-devops-boards]
+command = "/path/to/mcp-for-azure-devops-boards"
+```
+
+**Definition of Done**:
+
+- [ ] Module compiles without warnings
+- [ ] All 6 targets supported with correct format
+- [ ] JSON targets use correct key (`mcpServers` vs `servers`)
+- [ ] VS Code entries include `"type": "stdio"`
+- [ ] Codex uses TOML format
+- [ ] Parent directories created when needed
+- [ ] Existing config content preserved
+- [ ] Existing server entry updated on re-install
+- [ ] Error variants cover all failure modes (including `InvalidConfigFormat` for non-Object JSON root)
+
+---
+
+### Task 1.3: Expose install module
+
+**Action**: Modify `src/lib.rs` — add `pub mod install;`
+
+**Definition of Done**:
+
+- [ ] Module accessible from `main.rs` and integration tests
+
+---
+
+### Task 1.4: Integrate install flag into CLI
+
+**Action**: Modify `src/main.rs`
+
+Add import at the top of `src/main.rs`:
+
+```rust
+use mcp_for_azure_devops_boards::install::{InstallTarget, install, resolve_config_path, InstallError};
+```
+
+Add to `Args` struct:
+
+```rust
+/// Install MCP server configuration for the specified client
+#[arg(long, value_enum, conflicts_with = "server")]
+install: Option<InstallTarget>,
+```
+
+Add to `main()` body, **immediately after** `let args = Args::parse();` and **before** `let client = AzureDevOpsClient::new();` — the install path must NOT create the Azure client or MCP server since it is a pure file-write operation:
+
+```rust
+if let Some(target) = &args.install {
+    let binary_path = std::env::current_exe()
+        .map_err(InstallError::BinaryPathDetection)?;
+    let config_path = resolve_config_path(target)?;
+    let message = install(target, &config_path, &binary_path)?;
+    println!("{message}");
+    return Ok(());
+}
+```
+
+**Definition of Done**:
+
+- [ ] `--install <target>` flag accepted by CLI
+- [ ] Conflicts with `--server` (clap error if both provided)
+- [ ] Process exits after successful install with message
+- [ ] Error propagated correctly on failure
+
+---
+
+### Task 1.5: Unit tests for install module
+
+**File**: `src/install.rs` (`#[cfg(test)] mod tests`)
+
+**Setup**: `tempfile::TempDir` for isolated file system. Binary path simulated as `/test/path/mcp-for-azure-devops-boards`.
+
+| Test | Verifies |
+|------|----------|
+| `test_install_claude_code_creates_config` | Creates file with `{"mcpServers":{"mcp-for-azure-devops-boards":{"command":"..."}}}` from scratch |
+| `test_install_claude_desktop_creates_config` | Creates file with `{"mcpServers":{"mcp-for-azure-devops-boards":{"command":"..."}}}` from scratch |
+| `test_install_cursor_creates_config` | Creates file with `{"mcpServers":{"mcp-for-azure-devops-boards":{"command":"..."}}}` from scratch |
+| `test_install_gemini_cli_creates_config` | Creates file with `{"mcpServers":{"mcp-for-azure-devops-boards":{"command":"..."}}}` from scratch |
+| `test_install_vscode_creates_config` | Creates file with `{"servers":{"mcp-for-azure-devops-boards":{"type":"stdio","command":"..."}}}` from scratch |
+| `test_install_codex_creates_config` | Creates TOML file with `[mcp_servers.mcp-for-azure-devops-boards]` and `command = "..."` from scratch |
+| `test_install_json_preserves_existing_keys` | Pre-existing top-level keys (e.g. `"theme": "dark"`) remain after install |
+| `test_install_json_preserves_other_servers` | Pre-existing server entries in the `mcpServers` object remain after install |
+| `test_install_json_updates_existing_entry` | Re-running install with a different binary path updates the `command` value |
+| `test_install_toml_preserves_existing_keys` | Pre-existing TOML keys remain after install |
+| `test_install_toml_preserves_other_servers` | Pre-existing server entries in `mcp_servers` table remain after install |
+| `test_install_toml_updates_existing_entry` | Re-running install with a different binary path updates the `command` value |
+| `test_install_creates_parent_directories` | Config file written successfully when parent directories don't exist |
+| `test_install_returns_success_message` | Return value contains target name and config file path |
+| `test_install_json_invalid_json_returns_error` | Existing file with malformed JSON (e.g. `{broken`) returns `ParseJson` error |
+| `test_install_toml_invalid_toml_returns_error` | Existing file with malformed TOML returns `ParseToml` error |
+| `test_install_json_empty_file_treated_as_new` | Existing 0-byte file is treated as `{}` — install succeeds and produces correct config |
+| `test_install_json_root_not_object_returns_error` | Existing file with JSON array (`[]`) or primitive returns `InvalidConfigFormat` error |
+| `test_install_toml_empty_file_treated_as_new` | Existing 0-byte TOML file is treated as empty table — install succeeds and produces correct config |
+| `test_resolve_config_path_claude_code` | Path ends with `.claude.json` (assert suffix, not full path, to avoid host dependency) |
+| `test_resolve_config_path_cursor` | Path ends with `.cursor/mcp.json` |
+| `test_resolve_config_path_gemini_cli` | Path ends with `.gemini/settings.json` |
+| `test_resolve_config_path_codex` | Path ends with `.codex/config.toml` |
+| `test_resolve_config_path_vscode` | Path ends with `.vscode/mcp.json` |
+| `test_resolve_config_path_claude_desktop` | Path ends with `Claude/claude_desktop_config.json` |
+
+**File**: `src/main.rs` (`#[cfg(test)] mod tests`) — extend existing tests
+
+| Test | Verifies |
+|------|----------|
+| `test_install_flag_parsing` | `--install claude-code` parses correctly |
+| `test_install_conflicts_with_server` | `--install claude-code --server` is rejected by clap |
+| `test_install_all_targets_parse` | All 6 target values parse correctly |
+
+**Definition of Done**:
+
+- [ ] All 6 targets have config creation tests
+- [ ] Edge cases covered (existing config, re-install, directory creation, malformed input, empty files)
+- [ ] Path resolution tested for all targets (suffix assertions)
+
+---
+
+## User Story 2: E2E tests with testcontainers
+
+Verify config format compatibility with real CLI tools using Docker containers. Tests generate config with our install logic, inject it into a container running the real CLI tool, and verify the tool recognizes the server.
+
+### Acceptance Criteria
+
+- [ ] `testcontainers` dev-dependency added
+- [ ] Dockerfiles for test images (Claude Code, Cursor CLI, gemini-cli)
+- [ ] E2E tests for `claude-code`, `cursor`, `gemini-cli`
+- [ ] Tests verify real CLI tools recognize our generated config
+- [ ] Tests marked `#[ignore]` (opt-in via `cargo test --ignored`)
+- [ ] Makefile target for building test images and running E2E tests
+
+---
+
+### Task 2.1: Add testcontainers dev-dependency
+
+**Action**: Modify `Cargo.toml`
+
+Add to `[dev-dependencies]`:
+
+```toml
+testcontainers = "0.27"
+```
+
+**Definition of Done**:
+
+- [ ] `testcontainers` added to `[dev-dependencies]`
+
+---
+
+### Task 2.2: Create Dockerfiles for test images
+
+**Action**: Create `tests/docker/claude-code/Dockerfile`
+
+```dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"
+```
+
+**Action**: Create `tests/docker/cursor/Dockerfile`
+
+```dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl https://cursor.com/install -fsSL | bash
+ENV PATH="/root/.local/bin:${PATH}"
+```
+
+**Action**: Create `tests/docker/gemini-cli/Dockerfile`
+
+```dockerfile
+FROM node:20-slim
+RUN npm install -g @google/gemini-cli
+```
+
+**Definition of Done**:
+
+- [ ] All 3 Dockerfiles build successfully
+- [ ] CLI tools accessible inside containers (verified by running version commands)
+
+---
+
+### Task 2.3: Create E2E test file
+
+**Action**: Create `tests/test_install_e2e.rs`
+
+**Setup**: Each test is `#[ignore]` + `#[tokio::test]`.
+
+**Flow per test**:
+
+1. Call `install()` from the library with a temp directory path as the config location
+2. Read the generated config file content from the temp directory
+3. Start a testcontainer from the pre-built Docker image
+4. Write the config content into the container at the path the CLI tool expects (via exec using `echo` + base64 decode, or equivalent)
+5. Execute the CLI tool's list command inside the container
+6. Assert the output contains `mcp-for-azure-devops-boards`
+
+| Test | CLI tool | Config path inside container | Verification command |
+|------|----------|------------------------------|---------------------|
+| `test_e2e_claude_code_recognizes_config` | `claude` | `/root/.claude.json` | `claude mcp list` |
+| `test_e2e_cursor_recognizes_config` | `agent` | `/root/.cursor/mcp.json` | `agent mcp list` |
+| `test_e2e_gemini_cli_recognizes_config` | `gemini` | `/root/.gemini/settings.json` | `gemini mcp list` |
+
+**Definition of Done**:
+
+- [ ] Tests are `#[ignore]` and do not run with `cargo test`
+- [ ] 3 E2E tests created (one per CLI-verifiable target)
+
+---
+
+### Task 2.4: Add Makefile targets
+
+**Action**: Modify `Makefile`
+
+1. Update `.PHONY` declaration (line 1) to include new targets:
+
+```makefile
+.PHONY: all build release run check test lint fmt clean help test-e2e-build test-e2e
+```
+
+2. Add two targets after the `clean` target:
+
+```makefile
+test-e2e-build:
+	docker build -t mcp-test-claude-code tests/docker/claude-code/
+	docker build -t mcp-test-cursor tests/docker/cursor/
+	docker build -t mcp-test-gemini-cli tests/docker/gemini-cli/
+
+test-e2e: test-e2e-build
+	cargo test --features test-support --ignored
+```
+
+3. Update the `help` target to include the new entries:
+
+```makefile
+	@echo "  test-e2e-build - Build Docker images for E2E tests"
+	@echo "  test-e2e       - Run E2E testcontainers tests (requires Docker)"
+```
+
+**Definition of Done**:
+
+- [ ] `.PHONY` updated with `test-e2e-build` and `test-e2e`
+- [ ] `make test-e2e-build` builds all 3 Docker images
+- [ ] `make test-e2e` builds images and runs E2E tests
+- [ ] `make help` shows new targets
+- [ ] Existing Makefile targets unaffected
+
+---
+
+## User Story 3: README and documentation update
+
+Provide clear configuration examples for all supported MCP clients so users can set up the tool without guesswork.
+
+### Acceptance Criteria
+
+- [ ] README MCP Configuration section restructured with all 6 targets
+- [ ] macOS (Homebrew) and Windows (Scoop) binary paths shown
+- [ ] `--install` flag documented as quick setup alternative
+- [ ] `docs/PROJECT.md` updated with new dependencies and `--install` flag
+- [ ] `docs/ARCHITECTURE.md` updated with `src/install.rs`
+
+---
+
+### Task 3.1: Restructure README MCP Configuration section
+
+**Action**: Modify `README.md`
+
+Replace the current "MCP Configuration" section (lines 101–117, which only covers Claude Desktop) with a restructured section containing:
+
+1. **Quick setup with `--install`**: Show `mcp-for-azure-devops-boards --install <target>` as the fastest way. List all 6 valid target values.
+
+2. **Manual configuration** subsections for each target, in this order:
+   - **Claude Code**: Config at `~/.claude.json`. JSON with `mcpServers` key. Show macOS/Linux path (`/opt/homebrew/bin/mcp-for-azure-devops-boards`) and Windows path (`%USERPROFILE%\scoop\apps\mcp-for-azure-devops-boards\current\mcp-for-azure-devops-boards.exe`).
+   - **Claude Desktop**: Config at platform-specific paths (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`, Linux: `~/.config/Claude/claude_desktop_config.json`, Windows: `%APPDATA%\Claude\claude_desktop_config.json`). JSON with `mcpServers` key.
+   - **Cursor**: Config at `~/.cursor/mcp.json`. JSON with `mcpServers` key.
+   - **VS Code**: Config at `.vscode/mcp.json` (workspace level). JSON with `servers` key and `"type": "stdio"`.
+   - **gemini-cli**: Config at `~/.gemini/settings.json`. JSON with `mcpServers` key.
+   - **Codex CLI**: Config at `~/.codex/config.toml`. TOML with `[mcp_servers.mcp-for-azure-devops-boards]` section.
+
+Each manual config entry: one JSON/TOML code block with the macOS/Linux path, and a note with the Windows Scoop path to substitute. Keep it concise — no duplication of full blocks for each OS.
+
+**Definition of Done**:
+
+- [ ] All 6 targets documented
+- [ ] Both macOS (Homebrew) and Windows (Scoop) paths referenced
+- [ ] `--install` flag documented
+- [ ] Section is concise
+
+---
+
+### Task 3.2: Update docs/PROJECT.md
+
+**Action**: Modify `docs/PROJECT.md`
+
+- Add `dirs` and `toml` to the Runtime dependencies table
+- Add `testcontainers` and `tempfile` to the Dev dependencies table
+- Add `--install` row to the CLI flags table:
+
+  | Flag | Default | Description |
+  |------|---------|-------------|
+  | `--install` | — | Install MCP server configuration for the specified client (claude-code, claude-desktop, cursor, vscode, codex, gemini-cli) |
+
+**Definition of Done**:
+
+- [ ] Runtime dependencies table has `dirs` and `toml`
+- [ ] Dev dependencies table has `testcontainers` and `tempfile`
+- [ ] CLI flags table has `--install`
+
+---
+
+### Task 3.3: Update docs/ARCHITECTURE.md
+
+**Action**: Modify `docs/ARCHITECTURE.md`
+
+- Add `src/install.rs` to the project structure tree (under `src/`, after `compact_llm.rs`):
+  ```
+  │   ├── install.rs                # CLI --install: config generation for MCP clients
+  ```
+- Add `test_install_e2e.rs` and `tests/docker/` to the project structure tree:
+  ```
+  │   ├── test_install_e2e.rs       # E2E testcontainers tests for install config format
+  │   ├── docker/                   # Dockerfiles for E2E testcontainers tests
+  │   │   ├── claude-code/Dockerfile
+  │   │   ├── cursor/Dockerfile
+  │   │   └── gemini-cli/Dockerfile
+  ```
+- Update the `main.rs` line in the project structure to mention install flag:
+  ```
+  │   ├── main.rs                   # CLI entry (clap), transport selection, --install
+  ```
+
+**Definition of Done**:
+
+- [ ] `install.rs` appears in project structure
+- [ ] `tests/docker/` appears in project structure
+- [ ] `main.rs` description updated
+
+---
+
+## User Story 4: Final verification
+
+Verify the entire implementation end-to-end to ensure all quality gates pass and all behavior matches the plan.
+
+### Acceptance Criteria
+
+- [ ] All quality gates pass (`make fmt`, `make lint`, `make test`, `make build`)
+- [ ] All install targets produce correct output
+- [ ] E2E Docker images build and tests pass
+- [ ] Documentation updated and accurate
+- [ ] No code quality issues
+
+### Task 4.1: End-to-end verification of entire implementation
+
+#### Build and quality gates
+
+- [ ] `make fmt` passes (no formatting issues)
+- [ ] `make lint` passes (no clippy warnings)
+- [ ] `make test` passes (all unit + integration tests)
+- [ ] `make build` passes (no build warnings)
+
+#### Install flag behavior
+
+- [ ] `--install claude-code` produces correct JSON at `~/.claude.json` with `mcpServers` key
+- [ ] `--install claude-desktop` produces correct JSON at `<config_dir>/Claude/claude_desktop_config.json` with `mcpServers` key
+- [ ] `--install cursor` produces correct JSON at `~/.cursor/mcp.json` with `mcpServers` key
+- [ ] `--install vscode` produces correct JSON at `.vscode/mcp.json` with `servers` key and `"type": "stdio"`
+- [ ] `--install gemini-cli` produces correct JSON at `~/.gemini/settings.json` with `mcpServers` key
+- [ ] `--install codex` produces correct TOML at `~/.codex/config.toml` with `[mcp_servers.mcp-for-azure-devops-boards]`
+- [ ] `--install` and `--server` together are rejected by clap
+- [ ] `--install` with invalid target is rejected by clap
+- [ ] Existing config file content is preserved after install
+- [ ] Re-running install updates the binary path
+- [ ] Parent directories are created if missing
+
+#### E2E tests
+
+- [ ] `make test-e2e-build` builds all 3 Docker images without errors
+- [ ] `make test-e2e` runs and all E2E tests pass
+
+#### Documentation
+
+- [ ] README MCP Configuration section covers all 6 targets with correct formats
+- [ ] README mentions `--install` flag
+- [ ] `docs/PROJECT.md` has updated dependencies and CLI flag tables
+- [ ] `docs/ARCHITECTURE.md` has `install.rs` and `tests/docker/` in project structure
+
+#### Code quality
+
+- [ ] No TODOs in code
+- [ ] No dead code or commented-out code
+- [ ] No temporary hacks
+- [ ] Error handling covers all failure modes
+- [ ] Success messages are clear and include the config file path

--- a/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
+++ b/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
@@ -294,12 +294,12 @@ Verify config format compatibility with real CLI tools using Docker containers. 
 
 ### Acceptance Criteria
 
-- [ ] `testcontainers` dev-dependency added
-- [ ] Dockerfiles for test images (Claude Code, Cursor CLI, gemini-cli)
-- [ ] E2E tests for `claude-code`, `cursor`, `gemini-cli`
-- [ ] Tests verify real CLI tools recognize our generated config
-- [ ] Tests marked `#[ignore]` (opt-in via `cargo test --ignored`)
-- [ ] Makefile target for building test images and running E2E tests
+- [x] `testcontainers` dev-dependency added
+- [x] Dockerfiles for test images (Claude Code, Cursor CLI, gemini-cli)
+- [x] E2E tests for `claude-code`, `cursor`, `gemini-cli`
+- [x] Tests verify real CLI tools recognize our generated config
+- [x] Tests marked `#[ignore]` (opt-in via `cargo test --ignored`)
+- [x] Makefile target for building test images and running E2E tests
 
 ---
 
@@ -315,7 +315,7 @@ testcontainers = "0.27"
 
 **Definition of Done**:
 
-- [ ] `testcontainers` added to `[dev-dependencies]`
+- [x] `testcontainers` added to `[dev-dependencies]`
 
 ---
 
@@ -350,8 +350,8 @@ RUN npm install -g @google/gemini-cli
 
 **Definition of Done**:
 
-- [ ] All 3 Dockerfiles build successfully
-- [ ] CLI tools accessible inside containers (verified by running version commands)
+- [x] All 3 Dockerfiles build successfully
+- [x] CLI tools accessible inside containers (verified by running version commands)
 
 ---
 
@@ -378,8 +378,8 @@ RUN npm install -g @google/gemini-cli
 
 **Definition of Done**:
 
-- [ ] Tests are `#[ignore]` and do not run with `cargo test`
-- [ ] 3 E2E tests created (one per CLI-verifiable target)
+- [x] Tests are `#[ignore]` and do not run with `cargo test`
+- [x] 3 E2E tests created (one per CLI-verifiable target)
 
 ---
 
@@ -414,11 +414,11 @@ test-e2e: test-e2e-build
 
 **Definition of Done**:
 
-- [ ] `.PHONY` updated with `test-e2e-build` and `test-e2e`
-- [ ] `make test-e2e-build` builds all 3 Docker images
-- [ ] `make test-e2e` builds images and runs E2E tests
-- [ ] `make help` shows new targets
-- [ ] Existing Makefile targets unaffected
+- [x] `.PHONY` updated with `test-e2e-build` and `test-e2e`
+- [x] `make test-e2e-build` builds all 3 Docker images
+- [x] `make test-e2e` builds images and runs E2E tests
+- [x] `make help` shows new targets
+- [x] Existing Makefile targets unaffected
 
 ---
 

--- a/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
+++ b/docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md
@@ -428,11 +428,11 @@ Provide clear configuration examples for all supported MCP clients so users can 
 
 ### Acceptance Criteria
 
-- [ ] README MCP Configuration section restructured with all 6 targets
-- [ ] macOS (Homebrew) and Windows (Scoop) binary paths shown
-- [ ] `--install` flag documented as quick setup alternative
-- [ ] `docs/PROJECT.md` updated with new dependencies and `--install` flag
-- [ ] `docs/ARCHITECTURE.md` updated with `src/install.rs`
+- [x] README MCP Configuration section restructured with all 6 targets
+- [x] macOS (Homebrew) and Windows (Scoop) binary paths shown
+- [x] `--install` flag documented as quick setup alternative
+- [x] `docs/PROJECT.md` updated with new dependencies and `--install` flag
+- [x] `docs/ARCHITECTURE.md` updated with `src/install.rs`
 
 ---
 
@@ -456,10 +456,10 @@ Each manual config entry: one JSON/TOML code block with the macOS/Linux path, an
 
 **Definition of Done**:
 
-- [ ] All 6 targets documented
-- [ ] Both macOS (Homebrew) and Windows (Scoop) paths referenced
-- [ ] `--install` flag documented
-- [ ] Section is concise
+- [x] All 6 targets documented
+- [x] Both macOS (Homebrew) and Windows (Scoop) paths referenced
+- [x] `--install` flag documented
+- [x] Section is concise
 
 ---
 
@@ -477,9 +477,9 @@ Each manual config entry: one JSON/TOML code block with the macOS/Linux path, an
 
 **Definition of Done**:
 
-- [ ] Runtime dependencies table has `dirs` and `toml`
-- [ ] Dev dependencies table has `testcontainers` and `tempfile`
-- [ ] CLI flags table has `--install`
+- [x] Runtime dependencies table has `dirs` and `toml`
+- [x] Dev dependencies table has `testcontainers` and `tempfile`
+- [x] CLI flags table has `--install`
 
 ---
 
@@ -506,9 +506,9 @@ Each manual config entry: one JSON/TOML code block with the macOS/Linux path, an
 
 **Definition of Done**:
 
-- [ ] `install.rs` appears in project structure
-- [ ] `tests/docker/` appears in project structure
-- [ ] `main.rs` description updated
+- [x] `install.rs` appears in project structure
+- [x] `tests/docker/` appears in project structure
+- [x] `main.rs` description updated
 
 ---
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -96,9 +96,8 @@ pub fn resolve_config_path(target: &InstallTarget) -> Result<PathBuf, InstallErr
             Ok(home.join(".codex").join("config.toml"))
         }
         InstallTarget::Vscode => {
-            let cwd = std::env::current_dir().map_err(|e| InstallError::CurrentDirectoryNotFound {
-                source: e,
-            })?;
+            let cwd = std::env::current_dir()
+                .map_err(|e| InstallError::CurrentDirectoryNotFound { source: e })?;
             Ok(cwd.join(".vscode").join("mcp.json"))
         }
         InstallTarget::ClaudeDesktop => {
@@ -157,10 +156,12 @@ fn install_json(
             source: e,
         })?;
 
-    let root_obj = root.as_object_mut().ok_or_else(|| InstallError::InvalidConfigFormat {
-        path: config_path.to_path_buf(),
-        detail: "expected JSON object at root".to_string(),
-    })?;
+    let root_obj = root
+        .as_object_mut()
+        .ok_or_else(|| InstallError::InvalidConfigFormat {
+            path: config_path.to_path_buf(),
+            detail: "expected JSON object at root".to_string(),
+        })?;
 
     if !root_obj.contains_key(servers_key) {
         root_obj.insert(
@@ -190,10 +191,7 @@ fn install_json(
         serde_json::Value::String(binary_str.into_owned()),
     );
 
-    servers.insert(
-        SERVER_NAME.to_string(),
-        serde_json::Value::Object(entry),
-    );
+    servers.insert(SERVER_NAME.to_string(), serde_json::Value::Object(entry));
 
     let output = serde_json::to_string_pretty(&root).map_err(|e| InstallError::ParseJson {
         path: config_path.to_path_buf(),
@@ -221,11 +219,10 @@ fn install_toml(config_path: &Path, binary_path: &Path) -> Result<(), InstallErr
         }
     };
 
-    let mut root: toml::Value =
-        toml::from_str(&content).map_err(|e| InstallError::ParseToml {
-            path: config_path.to_path_buf(),
-            source: e,
-        })?;
+    let mut root: toml::Value = toml::from_str(&content).map_err(|e| InstallError::ParseToml {
+        path: config_path.to_path_buf(),
+        source: e,
+    })?;
 
     let root_table = root
         .as_table_mut()
@@ -290,9 +287,11 @@ mod tests {
             content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
             TEST_BINARY_PATH
         );
-        assert!(content["mcpServers"]["mcp-for-azure-devops-boards"]
-            .get("type")
-            .is_none());
+        assert!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]
+                .get("type")
+                .is_none()
+        );
     }
 
     #[test]
@@ -530,7 +529,10 @@ mod tests {
 
         let msg = install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
 
-        assert!(msg.contains("Claude Code"), "message should contain target name: {msg}");
+        assert!(
+            msg.contains("Claude Code"),
+            "message should contain target name: {msg}"
+        );
         assert!(
             msg.contains(&config_path.display().to_string()),
             "message should contain config path: {msg}"
@@ -633,8 +635,7 @@ mod tests {
     fn test_resolve_config_path_cursor() {
         let path = resolve_config_path(&InstallTarget::Cursor).unwrap();
         assert!(
-            path.ends_with(".cursor/mcp.json")
-                || path.ends_with(".cursor\\mcp.json"),
+            path.ends_with(".cursor/mcp.json") || path.ends_with(".cursor\\mcp.json"),
             "expected path ending with .cursor/mcp.json, got: {}",
             path.display()
         );
@@ -644,8 +645,7 @@ mod tests {
     fn test_resolve_config_path_gemini_cli() {
         let path = resolve_config_path(&InstallTarget::GeminiCli).unwrap();
         assert!(
-            path.ends_with(".gemini/settings.json")
-                || path.ends_with(".gemini\\settings.json"),
+            path.ends_with(".gemini/settings.json") || path.ends_with(".gemini\\settings.json"),
             "expected path ending with .gemini/settings.json, got: {}",
             path.display()
         );
@@ -655,8 +655,7 @@ mod tests {
     fn test_resolve_config_path_codex() {
         let path = resolve_config_path(&InstallTarget::Codex).unwrap();
         assert!(
-            path.ends_with(".codex/config.toml")
-                || path.ends_with(".codex\\config.toml"),
+            path.ends_with(".codex/config.toml") || path.ends_with(".codex\\config.toml"),
             "expected path ending with .codex/config.toml, got: {}",
             path.display()
         );
@@ -666,8 +665,7 @@ mod tests {
     fn test_resolve_config_path_vscode() {
         let path = resolve_config_path(&InstallTarget::Vscode).unwrap();
         assert!(
-            path.ends_with(".vscode/mcp.json")
-                || path.ends_with(".vscode\\mcp.json"),
+            path.ends_with(".vscode/mcp.json") || path.ends_with(".vscode\\mcp.json"),
             "expected path ending with .vscode/mcp.json, got: {}",
             path.display()
         );

--- a/src/install.rs
+++ b/src/install.rs
@@ -77,7 +77,7 @@ impl fmt::Display for InstallTarget {
     }
 }
 
-pub fn resolve_config_path(target: &InstallTarget) -> Result<PathBuf, InstallError> {
+pub fn resolve_config_path(target: &InstallTarget) -> Result<PathBuf, Box<InstallError>> {
     match target {
         InstallTarget::ClaudeCode => {
             let home = dirs::home_dir().ok_or(InstallError::HomeDirectoryNotFound)?;
@@ -111,7 +111,7 @@ pub fn install(
     target: &InstallTarget,
     config_path: &Path,
     binary_path: &Path,
-) -> Result<String, InstallError> {
+) -> Result<String, Box<InstallError>> {
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| InstallError::CreateDirectory {
             path: parent.to_path_buf(),
@@ -137,16 +137,16 @@ fn install_json(
     binary_path: &Path,
     servers_key: &str,
     include_type_stdio: bool,
-) -> Result<(), InstallError> {
+) -> Result<(), Box<InstallError>> {
     let content = match std::fs::read_to_string(config_path) {
         Ok(s) if s.is_empty() => "{}".to_string(),
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => "{}".to_string(),
         Err(e) => {
-            return Err(InstallError::ReadConfig {
+            return Err(Box::new(InstallError::ReadConfig {
                 path: config_path.to_path_buf(),
                 source: e,
-            });
+            }));
         }
     };
 
@@ -206,16 +206,16 @@ fn install_json(
     Ok(())
 }
 
-fn install_toml(config_path: &Path, binary_path: &Path) -> Result<(), InstallError> {
+fn install_toml(config_path: &Path, binary_path: &Path) -> Result<(), Box<InstallError>> {
     let content = match std::fs::read_to_string(config_path) {
         Ok(s) if s.is_empty() => String::new(),
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => {
-            return Err(InstallError::ReadConfig {
+            return Err(Box::new(InstallError::ReadConfig {
                 path: config_path.to_path_buf(),
                 source: e,
-            });
+            }));
         }
     };
 
@@ -550,7 +550,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            matches!(err, InstallError::ParseJson { .. }),
+            matches!(*err, InstallError::ParseJson { .. }),
             "expected ParseJson, got: {err}"
         );
     }
@@ -566,7 +566,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            matches!(err, InstallError::ParseToml { .. }),
+            matches!(*err, InstallError::ParseToml { .. }),
             "expected ParseToml, got: {err}"
         );
     }
@@ -598,7 +598,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            matches!(err, InstallError::InvalidConfigFormat { .. }),
+            matches!(*err, InstallError::InvalidConfigFormat { .. }),
             "expected InvalidConfigFormat, got: {err}"
         );
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,0 +1,686 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+const SERVER_NAME: &str = "mcp-for-azure-devops-boards";
+
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("Could not determine home directory")]
+    HomeDirectoryNotFound,
+
+    #[error("Could not determine config directory")]
+    ConfigDirectoryNotFound,
+
+    #[error("Could not determine current directory: {source}")]
+    CurrentDirectoryNotFound { source: std::io::Error },
+
+    #[error("Could not detect binary path: {source}")]
+    BinaryPathDetection { source: std::io::Error },
+
+    #[error("Failed to create directory {}: {source}", path.display())]
+    CreateDirectory {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("Failed to read config file {}: {source}", path.display())]
+    ReadConfig {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("Failed to write config file {}: {source}", path.display())]
+    WriteConfig {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("Failed to parse JSON config {}: {source}", path.display())]
+    ParseJson {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[error("Failed to parse TOML config {}: {source}", path.display())]
+    ParseToml {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[error("Failed to serialize TOML config: {source}")]
+    SerializeToml { source: toml::ser::Error },
+
+    #[error("Invalid config format in {}: {detail}", path.display())]
+    InvalidConfigFormat { path: PathBuf, detail: String },
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum InstallTarget {
+    ClaudeCode,
+    ClaudeDesktop,
+    Cursor,
+    Vscode,
+    Codex,
+    GeminiCli,
+}
+
+impl fmt::Display for InstallTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InstallTarget::ClaudeCode => write!(f, "Claude Code"),
+            InstallTarget::ClaudeDesktop => write!(f, "Claude Desktop"),
+            InstallTarget::Cursor => write!(f, "Cursor"),
+            InstallTarget::Vscode => write!(f, "VS Code"),
+            InstallTarget::Codex => write!(f, "Codex CLI"),
+            InstallTarget::GeminiCli => write!(f, "gemini-cli"),
+        }
+    }
+}
+
+pub fn resolve_config_path(target: &InstallTarget) -> Result<PathBuf, InstallError> {
+    match target {
+        InstallTarget::ClaudeCode => {
+            let home = dirs::home_dir().ok_or(InstallError::HomeDirectoryNotFound)?;
+            Ok(home.join(".claude.json"))
+        }
+        InstallTarget::Cursor => {
+            let home = dirs::home_dir().ok_or(InstallError::HomeDirectoryNotFound)?;
+            Ok(home.join(".cursor").join("mcp.json"))
+        }
+        InstallTarget::GeminiCli => {
+            let home = dirs::home_dir().ok_or(InstallError::HomeDirectoryNotFound)?;
+            Ok(home.join(".gemini").join("settings.json"))
+        }
+        InstallTarget::Codex => {
+            let home = dirs::home_dir().ok_or(InstallError::HomeDirectoryNotFound)?;
+            Ok(home.join(".codex").join("config.toml"))
+        }
+        InstallTarget::Vscode => {
+            let cwd = std::env::current_dir().map_err(|e| InstallError::CurrentDirectoryNotFound {
+                source: e,
+            })?;
+            Ok(cwd.join(".vscode").join("mcp.json"))
+        }
+        InstallTarget::ClaudeDesktop => {
+            let config = dirs::config_dir().ok_or(InstallError::ConfigDirectoryNotFound)?;
+            Ok(config.join("Claude").join("claude_desktop_config.json"))
+        }
+    }
+}
+
+pub fn install(
+    target: &InstallTarget,
+    config_path: &Path,
+    binary_path: &Path,
+) -> Result<String, InstallError> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| InstallError::CreateDirectory {
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    match target {
+        InstallTarget::Codex => install_toml(config_path, binary_path)?,
+        InstallTarget::Vscode => install_json(config_path, binary_path, "servers", true)?,
+        _ => install_json(config_path, binary_path, "mcpServers", false)?,
+    }
+
+    Ok(format!(
+        "Installed {} configuration at {}",
+        target,
+        config_path.display()
+    ))
+}
+
+fn install_json(
+    config_path: &Path,
+    binary_path: &Path,
+    servers_key: &str,
+    include_type_stdio: bool,
+) -> Result<(), InstallError> {
+    let content = match std::fs::read_to_string(config_path) {
+        Ok(s) if s.is_empty() => "{}".to_string(),
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => "{}".to_string(),
+        Err(e) => {
+            return Err(InstallError::ReadConfig {
+                path: config_path.to_path_buf(),
+                source: e,
+            });
+        }
+    };
+
+    let mut root: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| InstallError::ParseJson {
+            path: config_path.to_path_buf(),
+            source: e,
+        })?;
+
+    let root_obj = root.as_object_mut().ok_or_else(|| InstallError::InvalidConfigFormat {
+        path: config_path.to_path_buf(),
+        detail: "expected JSON object at root".to_string(),
+    })?;
+
+    if !root_obj.contains_key(servers_key) {
+        root_obj.insert(
+            servers_key.to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    let servers = root_obj
+        .get_mut(servers_key)
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| InstallError::InvalidConfigFormat {
+            path: config_path.to_path_buf(),
+            detail: format!("expected \"{servers_key}\" to be an object"),
+        })?;
+
+    let binary_str = binary_path.to_string_lossy();
+    let mut entry = serde_json::Map::new();
+    if include_type_stdio {
+        entry.insert(
+            "type".to_string(),
+            serde_json::Value::String("stdio".to_string()),
+        );
+    }
+    entry.insert(
+        "command".to_string(),
+        serde_json::Value::String(binary_str.into_owned()),
+    );
+
+    servers.insert(
+        SERVER_NAME.to_string(),
+        serde_json::Value::Object(entry),
+    );
+
+    let output = serde_json::to_string_pretty(&root).map_err(|e| InstallError::ParseJson {
+        path: config_path.to_path_buf(),
+        source: e,
+    })?;
+
+    std::fs::write(config_path, format!("{output}\n")).map_err(|e| InstallError::WriteConfig {
+        path: config_path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
+}
+
+fn install_toml(config_path: &Path, binary_path: &Path) -> Result<(), InstallError> {
+    let content = match std::fs::read_to_string(config_path) {
+        Ok(s) if s.is_empty() => String::new(),
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(InstallError::ReadConfig {
+                path: config_path.to_path_buf(),
+                source: e,
+            });
+        }
+    };
+
+    let mut root: toml::Value =
+        toml::from_str(&content).map_err(|e| InstallError::ParseToml {
+            path: config_path.to_path_buf(),
+            source: e,
+        })?;
+
+    let root_table = root
+        .as_table_mut()
+        .ok_or_else(|| InstallError::InvalidConfigFormat {
+            path: config_path.to_path_buf(),
+            detail: "expected TOML table at root".to_string(),
+        })?;
+
+    if !root_table.contains_key("mcp_servers") {
+        root_table.insert(
+            "mcp_servers".to_string(),
+            toml::Value::Table(toml::map::Map::new()),
+        );
+    }
+
+    let mcp_servers = root_table
+        .get_mut("mcp_servers")
+        .and_then(|v| v.as_table_mut())
+        .ok_or_else(|| InstallError::InvalidConfigFormat {
+            path: config_path.to_path_buf(),
+            detail: "expected \"mcp_servers\" to be a table".to_string(),
+        })?;
+
+    let binary_str = binary_path.to_string_lossy().into_owned();
+    let mut entry = toml::map::Map::new();
+    entry.insert("command".to_string(), toml::Value::String(binary_str));
+
+    mcp_servers.insert(SERVER_NAME.to_string(), toml::Value::Table(entry));
+
+    let output =
+        toml::to_string_pretty(&root).map_err(|e| InstallError::SerializeToml { source: e })?;
+
+    std::fs::write(config_path, output).map_err(|e| InstallError::WriteConfig {
+        path: config_path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const TEST_BINARY_PATH: &str = "/test/path/mcp-for-azure-devops-boards";
+
+    fn binary_path() -> PathBuf {
+        PathBuf::from(TEST_BINARY_PATH)
+    }
+
+    #[test]
+    fn test_install_claude_code_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".claude.json");
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+        assert!(content["mcpServers"]["mcp-for-azure-devops-boards"]
+            .get("type")
+            .is_none());
+    }
+
+    #[test]
+    fn test_install_claude_desktop_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("Claude").join("claude_desktop_config.json");
+
+        install(&InstallTarget::ClaudeDesktop, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_cursor_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".cursor").join("mcp.json");
+
+        install(&InstallTarget::Cursor, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_gemini_cli_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".gemini").join("settings.json");
+
+        install(&InstallTarget::GeminiCli, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_vscode_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".vscode").join("mcp.json");
+
+        install(&InstallTarget::Vscode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["servers"]["mcp-for-azure-devops-boards"]["type"],
+            "stdio"
+        );
+        assert_eq!(
+            content["servers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_codex_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".codex").join("config.toml");
+
+        install(&InstallTarget::Codex, &config_path, &binary_path()).unwrap();
+
+        let content: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcp_servers"]["mcp-for-azure-devops-boards"]["command"]
+                .as_str()
+                .unwrap(),
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_json_preserves_existing_keys() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(&config_path, r#"{"theme": "dark", "fontSize": 14}"#).unwrap();
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(content["theme"], "dark");
+        assert_eq!(content["fontSize"], 14);
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_json_preserves_other_servers() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"mcpServers": {"other-server": {"command": "/other/bin"}}}"#,
+        )
+        .unwrap();
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["other-server"]["command"],
+            "/other/bin"
+        );
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_json_updates_existing_entry() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"mcpServers": {"mcp-for-azure-devops-boards": {"command": "/old/path"}}}"#,
+        )
+        .unwrap();
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_toml_preserves_existing_keys() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "model = \"gpt-4\"\n").unwrap();
+
+        install(&InstallTarget::Codex, &config_path, &binary_path()).unwrap();
+
+        let content: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(content["model"].as_str().unwrap(), "gpt-4");
+        assert_eq!(
+            content["mcp_servers"]["mcp-for-azure-devops-boards"]["command"]
+                .as_str()
+                .unwrap(),
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_toml_preserves_other_servers() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[mcp_servers.other-server]\ncommand = \"/other/bin\"\n",
+        )
+        .unwrap();
+
+        install(&InstallTarget::Codex, &config_path, &binary_path()).unwrap();
+
+        let content: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcp_servers"]["other-server"]["command"]
+                .as_str()
+                .unwrap(),
+            "/other/bin"
+        );
+        assert_eq!(
+            content["mcp_servers"]["mcp-for-azure-devops-boards"]["command"]
+                .as_str()
+                .unwrap(),
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_toml_updates_existing_entry() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[mcp_servers.mcp-for-azure-devops-boards]\ncommand = \"/old/path\"\n",
+        )
+        .unwrap();
+
+        install(&InstallTarget::Codex, &config_path, &binary_path()).unwrap();
+
+        let content: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcp_servers"]["mcp-for-azure-devops-boards"]["command"]
+                .as_str()
+                .unwrap(),
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_creates_parent_directories() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("deep").join("nested").join("config.json");
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        assert!(config_path.exists());
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_returns_success_message() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+
+        let msg = install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        assert!(msg.contains("Claude Code"), "message should contain target name: {msg}");
+        assert!(
+            msg.contains(&config_path.display().to_string()),
+            "message should contain config path: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_install_json_invalid_json_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(&config_path, "{broken").unwrap();
+
+        let result = install(&InstallTarget::ClaudeCode, &config_path, &binary_path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, InstallError::ParseJson { .. }),
+            "expected ParseJson, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_install_toml_invalid_toml_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[broken\ninvalid toml").unwrap();
+
+        let result = install(&InstallTarget::Codex, &config_path, &binary_path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, InstallError::ParseToml { .. }),
+            "expected ParseToml, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_install_json_empty_file_treated_as_new() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(&config_path, "").unwrap();
+
+        install(&InstallTarget::ClaudeCode, &config_path, &binary_path()).unwrap();
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcpServers"]["mcp-for-azure-devops-boards"]["command"],
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_install_json_root_not_object_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.json");
+        std::fs::write(&config_path, "[1, 2, 3]").unwrap();
+
+        let result = install(&InstallTarget::ClaudeCode, &config_path, &binary_path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, InstallError::InvalidConfigFormat { .. }),
+            "expected InvalidConfigFormat, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_install_toml_empty_file_treated_as_new() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        install(&InstallTarget::Codex, &config_path, &binary_path()).unwrap();
+
+        let content: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(
+            content["mcp_servers"]["mcp-for-azure-devops-boards"]["command"]
+                .as_str()
+                .unwrap(),
+            TEST_BINARY_PATH
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_claude_code() {
+        let path = resolve_config_path(&InstallTarget::ClaudeCode).unwrap();
+        assert!(
+            path.ends_with(".claude.json"),
+            "expected path ending with .claude.json, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_cursor() {
+        let path = resolve_config_path(&InstallTarget::Cursor).unwrap();
+        assert!(
+            path.ends_with(".cursor/mcp.json")
+                || path.ends_with(".cursor\\mcp.json"),
+            "expected path ending with .cursor/mcp.json, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_gemini_cli() {
+        let path = resolve_config_path(&InstallTarget::GeminiCli).unwrap();
+        assert!(
+            path.ends_with(".gemini/settings.json")
+                || path.ends_with(".gemini\\settings.json"),
+            "expected path ending with .gemini/settings.json, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_codex() {
+        let path = resolve_config_path(&InstallTarget::Codex).unwrap();
+        assert!(
+            path.ends_with(".codex/config.toml")
+                || path.ends_with(".codex\\config.toml"),
+            "expected path ending with .codex/config.toml, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_vscode() {
+        let path = resolve_config_path(&InstallTarget::Vscode).unwrap();
+        assert!(
+            path.ends_with(".vscode/mcp.json")
+                || path.ends_with(".vscode\\mcp.json"),
+            "expected path ending with .vscode/mcp.json, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_path_claude_desktop() {
+        let path = resolve_config_path(&InstallTarget::ClaudeDesktop).unwrap();
+        assert!(
+            path.ends_with("Claude/claude_desktop_config.json")
+                || path.ends_with("Claude\\claude_desktop_config.json"),
+            "expected path ending with Claude/claude_desktop_config.json, got: {}",
+            path.display()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod azure;
 pub mod compact_llm;
+pub mod install;
 pub mod mcp;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use mcp_for_azure_devops_boards::azure::client::AzureDevOpsClient;
-use mcp_for_azure_devops_boards::install::{InstallError, InstallTarget, install, resolve_config_path};
+use mcp_for_azure_devops_boards::install::{
+    InstallError, InstallTarget, install, resolve_config_path,
+};
 use mcp_for_azure_devops_boards::mcp::server::AzureMcpServer;
 use mcp_for_azure_devops_boards::server::http;
 use rmcp::ServiceExt;
@@ -28,8 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     if let Some(target) = &args.install {
-        let binary_path = std::env::current_exe()
-            .map_err(|e| InstallError::BinaryPathDetection { source: e })?;
+        let binary_path =
+            std::env::current_exe().map_err(|e| InstallError::BinaryPathDetection { source: e })?;
         let config_path = resolve_config_path(target)?;
         let message = install(target, &config_path, &binary_path)?;
         println!("{message}");
@@ -89,10 +91,7 @@ mod tests {
     fn test_install_flag_parsing() {
         let args = Args::try_parse_from(["test", "--install", "claude-code"]).unwrap();
         assert!(args.install.is_some());
-        assert!(matches!(
-            args.install.unwrap(),
-            InstallTarget::ClaudeCode
-        ));
+        assert!(matches!(args.install.unwrap(), InstallTarget::ClaudeCode));
     }
 
     #[test]
@@ -112,11 +111,13 @@ mod tests {
             "gemini-cli",
         ];
         for target in targets {
-            let args =
-                Args::try_parse_from(["test", "--install", target]).unwrap_or_else(|e| {
-                    panic!("failed to parse --install {target}: {e}");
-                });
-            assert!(args.install.is_some(), "install should be Some for {target}");
+            let args = Args::try_parse_from(["test", "--install", target]).unwrap_or_else(|e| {
+                panic!("failed to parse --install {target}: {e}");
+            });
+            assert!(
+                args.install.is_some(),
+                "install should be Some for {target}"
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use mcp_for_azure_devops_boards::azure::client::AzureDevOpsClient;
+use mcp_for_azure_devops_boards::install::{InstallError, InstallTarget, install, resolve_config_path};
 use mcp_for_azure_devops_boards::mcp::server::AzureMcpServer;
 use mcp_for_azure_devops_boards::server::http;
 use rmcp::ServiceExt;
@@ -15,12 +16,25 @@ pub(crate) struct Args {
     /// Port to run the server on
     #[arg(long, default_value_t = 3000)]
     port: u16,
+
+    /// Install MCP server configuration for the specified client
+    #[arg(long, value_enum, conflicts_with = "server")]
+    install: Option<InstallTarget>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let args = Args::parse();
+
+    if let Some(target) = &args.install {
+        let binary_path = std::env::current_exe()
+            .map_err(|e| InstallError::BinaryPathDetection { source: e })?;
+        let config_path = resolve_config_path(target)?;
+        let message = install(target, &config_path, &binary_path)?;
+        println!("{message}");
+        return Ok(());
+    }
 
     let client = AzureDevOpsClient::new();
     let mcp_server = AzureMcpServer::new(client);
@@ -69,5 +83,40 @@ mod tests {
         let args = Args::try_parse_from(["test", "--server", "--port", "8080"]).unwrap();
         assert!(args.server);
         assert_eq!(args.port, 8080);
+    }
+
+    #[test]
+    fn test_install_flag_parsing() {
+        let args = Args::try_parse_from(["test", "--install", "claude-code"]).unwrap();
+        assert!(args.install.is_some());
+        assert!(matches!(
+            args.install.unwrap(),
+            InstallTarget::ClaudeCode
+        ));
+    }
+
+    #[test]
+    fn test_install_conflicts_with_server() {
+        let result = Args::try_parse_from(["test", "--install", "claude-code", "--server"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_install_all_targets_parse() {
+        let targets = [
+            "claude-code",
+            "claude-desktop",
+            "cursor",
+            "vscode",
+            "codex",
+            "gemini-cli",
+        ];
+        for target in targets {
+            let args =
+                Args::try_parse_from(["test", "--install", target]).unwrap_or_else(|e| {
+                    panic!("failed to parse --install {target}: {e}");
+                });
+            assert!(args.install.is_some(), "install should be Some for {target}");
+        }
     }
 }

--- a/tests/docker/claude-code/Dockerfile
+++ b/tests/docker/claude-code/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"

--- a/tests/docker/cursor/Dockerfile
+++ b/tests/docker/cursor/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl https://cursor.com/install -fsSL | bash
+ENV PATH="/root/.local/bin:${PATH}"

--- a/tests/docker/gemini-cli/Dockerfile
+++ b/tests/docker/gemini-cli/Dockerfile
@@ -1,2 +1,2 @@
 FROM node:20-slim
-RUN npm install -g @google/gemini-cli
+RUN npm install -g @google/gemini-cli && mkdir -p /root/.gemini

--- a/tests/docker/gemini-cli/Dockerfile
+++ b/tests/docker/gemini-cli/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:20-slim
+RUN npm install -g @google/gemini-cli

--- a/tests/test_install_e2e.rs
+++ b/tests/test_install_e2e.rs
@@ -45,13 +45,15 @@ async fn run_e2e_install_test(
         .await
         .unwrap_or_else(|e| panic!("Failed to write config into container: {e}"));
 
-    let result = container
+    let mut result = container
         .exec(ExecCommand::new(verify_command.clone()))
         .await
         .unwrap_or_else(|e| panic!("Failed to exec verify command: {e}"));
 
-    let stdout = String::from_utf8_lossy(&result.stdout_to_vec().await.unwrap_or_default());
-    let stderr = String::from_utf8_lossy(&result.stderr_to_vec().await.unwrap_or_default());
+    let stdout_bytes = result.stdout_to_vec().await.unwrap_or_default();
+    let stderr_bytes = result.stderr_to_vec().await.unwrap_or_default();
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
+    let stderr = String::from_utf8_lossy(&stderr_bytes);
     let combined = format!("{stdout}{stderr}");
 
     assert!(
@@ -67,11 +69,7 @@ async fn test_e2e_claude_code_recognizes_config() {
         "mcp-test-claude-code",
         InstallTarget::ClaudeCode,
         "/root/.claude.json",
-        vec![
-            "claude".to_string(),
-            "mcp".to_string(),
-            "list".to_string(),
-        ],
+        vec!["claude".to_string(), "mcp".to_string(), "list".to_string()],
     )
     .await;
 }
@@ -83,11 +81,7 @@ async fn test_e2e_cursor_recognizes_config() {
         "mcp-test-cursor",
         InstallTarget::Cursor,
         "/root/.cursor/mcp.json",
-        vec![
-            "agent".to_string(),
-            "mcp".to_string(),
-            "list".to_string(),
-        ],
+        vec!["agent".to_string(), "mcp".to_string(), "list".to_string()],
     )
     .await;
 }
@@ -99,11 +93,7 @@ async fn test_e2e_gemini_cli_recognizes_config() {
         "mcp-test-gemini-cli",
         InstallTarget::GeminiCli,
         "/root/.gemini/settings.json",
-        vec![
-            "gemini".to_string(),
-            "mcp".to_string(),
-            "list".to_string(),
-        ],
+        vec!["gemini".to_string(), "mcp".to_string(), "list".to_string()],
     )
     .await;
 }

--- a/tests/test_install_e2e.rs
+++ b/tests/test_install_e2e.rs
@@ -100,7 +100,7 @@ async fn test_e2e_gemini_cli_recognizes_config() {
         InstallTarget::GeminiCli,
         "/root/.gemini/settings.json",
         vec!["gemini".to_string(), "mcp".to_string(), "list".to_string()],
-        vec![("GOOGLE_GENAI_USE_GCA", "true")],
+        vec![("GEMINI_API_KEY", "dummy")],
     )
     .await;
 }

--- a/tests/test_install_e2e.rs
+++ b/tests/test_install_e2e.rs
@@ -15,6 +15,7 @@ async fn run_e2e_install_test(
     target: InstallTarget,
     config_path_in_container: &str,
     verify_command: Vec<String>,
+    env_vars: Vec<(&str, &str)>,
 ) {
     let tmp = tempfile::TempDir::new().unwrap();
     let config_path = tmp.path().join("config_file");
@@ -35,9 +36,13 @@ async fn run_e2e_install_test(
         "mkdir -p '{parent_dir}' && echo '{encoded}' | base64 -d > '{config_path_in_container}'"
     );
 
-    let container = GenericImage::new(image_name, "latest")
+    let mut image = GenericImage::new(image_name, "latest")
         .with_wait_for(WaitFor::seconds(2))
-        .with_cmd(vec!["sleep", "infinity"])
+        .with_cmd(vec!["sleep", "infinity"]);
+    for (key, val) in &env_vars {
+        image = image.with_env_var(*key, *val);
+    }
+    let container = image
         .start()
         .await
         .unwrap_or_else(|e| panic!("Failed to start container {image_name}: {e}"));
@@ -71,6 +76,7 @@ async fn test_e2e_claude_code_recognizes_config() {
         InstallTarget::ClaudeCode,
         "/root/.claude.json",
         vec!["claude".to_string(), "mcp".to_string(), "list".to_string()],
+        vec![],
     )
     .await;
 }
@@ -82,6 +88,7 @@ async fn test_e2e_cursor_recognizes_config() {
         InstallTarget::Cursor,
         "/root/.cursor/mcp.json",
         vec!["agent".to_string(), "mcp".to_string(), "list".to_string()],
+        vec![],
     )
     .await;
 }
@@ -93,6 +100,7 @@ async fn test_e2e_gemini_cli_recognizes_config() {
         InstallTarget::GeminiCli,
         "/root/.gemini/settings.json",
         vec!["gemini".to_string(), "mcp".to_string(), "list".to_string()],
+        vec![("GOOGLE_GENAI_USE_GCA", "true")],
     )
     .await;
 }

--- a/tests/test_install_e2e.rs
+++ b/tests/test_install_e2e.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "e2e-tests")]
+
 use std::path::PathBuf;
 
 use base64::Engine;
@@ -62,7 +64,6 @@ async fn run_e2e_install_test(
     );
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_e2e_claude_code_recognizes_config() {
     run_e2e_install_test(
@@ -74,7 +75,6 @@ async fn test_e2e_claude_code_recognizes_config() {
     .await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_e2e_cursor_recognizes_config() {
     run_e2e_install_test(
@@ -86,7 +86,6 @@ async fn test_e2e_cursor_recognizes_config() {
     .await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_e2e_gemini_cli_recognizes_config() {
     run_e2e_install_test(

--- a/tests/test_install_e2e.rs
+++ b/tests/test_install_e2e.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+
+use base64::Engine;
+use mcp_for_azure_devops_boards::install::{InstallTarget, install};
+use testcontainers::core::{ExecCommand, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{GenericImage, ImageExt};
+
+const SERVER_NAME: &str = "mcp-for-azure-devops-boards";
+
+async fn run_e2e_install_test(
+    image_name: &str,
+    target: InstallTarget,
+    config_path_in_container: &str,
+    verify_command: Vec<String>,
+) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config_path = tmp.path().join("config_file");
+    let binary_path = PathBuf::from("/usr/local/bin/mcp-for-azure-devops-boards");
+
+    install(&target, &config_path, &binary_path).unwrap();
+
+    let config_content = std::fs::read_to_string(&config_path).unwrap();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(config_content.as_bytes());
+
+    let parent_dir = std::path::Path::new(config_path_in_container)
+        .parent()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let setup_script = format!(
+        "mkdir -p '{parent_dir}' && echo '{encoded}' | base64 -d > '{config_path_in_container}'"
+    );
+
+    let container = GenericImage::new(image_name, "latest")
+        .with_wait_for(WaitFor::seconds(2))
+        .with_cmd(vec!["sleep", "infinity"])
+        .start()
+        .await
+        .unwrap_or_else(|e| panic!("Failed to start container {image_name}: {e}"));
+
+    container
+        .exec(ExecCommand::new(vec!["bash", "-c", &setup_script]))
+        .await
+        .unwrap_or_else(|e| panic!("Failed to write config into container: {e}"));
+
+    let result = container
+        .exec(ExecCommand::new(verify_command.clone()))
+        .await
+        .unwrap_or_else(|e| panic!("Failed to exec verify command: {e}"));
+
+    let stdout = String::from_utf8_lossy(&result.stdout_to_vec().await.unwrap_or_default());
+    let stderr = String::from_utf8_lossy(&result.stderr_to_vec().await.unwrap_or_default());
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        combined.contains(SERVER_NAME),
+        "Expected output to contain '{SERVER_NAME}', got stdout: {stdout}, stderr: {stderr}"
+    );
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_e2e_claude_code_recognizes_config() {
+    run_e2e_install_test(
+        "mcp-test-claude-code",
+        InstallTarget::ClaudeCode,
+        "/root/.claude.json",
+        vec![
+            "claude".to_string(),
+            "mcp".to_string(),
+            "list".to_string(),
+        ],
+    )
+    .await;
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_e2e_cursor_recognizes_config() {
+    run_e2e_install_test(
+        "mcp-test-cursor",
+        InstallTarget::Cursor,
+        "/root/.cursor/mcp.json",
+        vec![
+            "agent".to_string(),
+            "mcp".to_string(),
+            "list".to_string(),
+        ],
+    )
+    .await;
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_e2e_gemini_cli_recognizes_config() {
+    run_e2e_install_test(
+        "mcp-test-gemini-cli",
+        InstallTarget::GeminiCli,
+        "/root/.gemini/settings.json",
+        vec![
+            "gemini".to_string(),
+            "mcp".to_string(),
+            "list".to_string(),
+        ],
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

- Adds `--install <target>` CLI flag for auto-registering the MCP server with 6 clients: Claude Code, Claude Desktop, Cursor, VS Code, gemini-cli, and Codex CLI
- Generates correct JSON (`mcpServers`/`servers`) or TOML (`mcp_servers`) config files per target, preserves existing config content, creates parent directories
- Includes 25 unit tests covering all targets, edge cases (malformed input, empty files, re-install), and path resolution
- Adds 3 E2E testcontainers tests (Claude Code, Cursor CLI, gemini-cli) to verify config format compatibility with real CLI tools
- Restructures README MCP Configuration section with all 6 targets, macOS/Windows binary paths, and quick `--install` setup guide
- Updates `docs/PROJECT.md` and `docs/ARCHITECTURE.md` with new dependencies and module

## Test plan

- [x] `make fmt` passes
- [x] `make lint` passes (zero clippy warnings)
- [x] `make test` passes (84 unit tests + 80 integration tests)
- [x] `make build` passes
- [x] `make test-e2e` — requires Docker and pre-built images (run manually)

Plan: `docs/plans/3_cli_install_flag_mcp_client_config_20260312160258.md`