### PR TITLE
feat(tools): add justification field to create/update work item tools

### DIFF
--- a/src/mcp/tools/work_items/create_work_item.rs
+++ b/src/mcp/tools/work_items/create_work_item.rs
@@ -29,7 +29,7 @@ pub struct CreateWorkItemArgs {
     #[serde(deserialize_with = "deserialize_non_empty_string")]
     pub title: String,
 
-    /// Format for large text fields (description, acceptance criteria, repro steps): "markdown" or "html" (default: "markdown")
+    /// Format for large text fields (description, acceptance criteria, repro steps, justification): "markdown" or "html" (default: "markdown")
     #[serde(default = "default_text_format")]
     pub format: String,
 
@@ -117,6 +117,10 @@ pub struct CreateWorkItemArgs {
     #[serde(default)]
     pub repro_steps: Option<String>,
 
+    /// Justification (CMMI process template; use markdown syntax when format is "markdown", HTML tags when format is "html")
+    #[serde(default)]
+    pub justification: Option<String>,
+
     /// Optional extra fields as JSON string (for custom fields)
     #[serde(default)]
     pub fields: Option<String>,
@@ -160,6 +164,12 @@ pub async fn create_work_item(
         if args.repro_steps.is_some() {
             multiline_formats.push((
                 "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                "Markdown".to_string(),
+            ));
+        }
+        if args.justification.is_some() {
+            multiline_formats.push((
+                "Microsoft.VSTS.CMMI.Justification".to_string(),
                 "Markdown".to_string(),
             ));
         }
@@ -275,6 +285,12 @@ pub async fn create_work_item(
         field_map.insert(
             "Microsoft.VSTS.TCM.ReproSteps".to_string(),
             serde_json::json!(repro_steps),
+        );
+    }
+    if let Some(justification) = &args.justification {
+        field_map.insert(
+            "Microsoft.VSTS.CMMI.Justification".to_string(),
+            serde_json::json!(justification),
         );
     }
 
@@ -443,7 +459,7 @@ mod tests {
     #[test]
     fn test_create_work_item_multiline_formats_built_for_markdown() {
         let args = deserialize_args(
-            r#"{"organization":"org","project":"proj","work_item_type":"Bug","title":"t","description":"desc","acceptance_criteria":"ac","repro_steps":"steps"}"#,
+            r#"{"organization":"org","project":"proj","work_item_type":"Bug","title":"t","description":"desc","acceptance_criteria":"ac","repro_steps":"steps","justification":"why"}"#,
         )
         .unwrap();
 
@@ -465,9 +481,15 @@ mod tests {
                     "Markdown".to_string(),
                 ));
             }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
         }
 
-        assert_eq!(multiline_formats.len(), 3);
+        assert_eq!(multiline_formats.len(), 4);
         assert_eq!(
             multiline_formats[0],
             ("System.Description".to_string(), "Markdown".to_string())
@@ -486,12 +508,19 @@ mod tests {
                 "Markdown".to_string()
             )
         );
+        assert_eq!(
+            multiline_formats[3],
+            (
+                "Microsoft.VSTS.CMMI.Justification".to_string(),
+                "Markdown".to_string()
+            )
+        );
     }
 
     #[test]
     fn test_create_work_item_multiline_formats_empty_for_html() {
         let args = deserialize_args(
-            r#"{"organization":"org","project":"proj","work_item_type":"Bug","title":"t","format":"html","description":"desc","acceptance_criteria":"ac","repro_steps":"steps"}"#,
+            r#"{"organization":"org","project":"proj","work_item_type":"Bug","title":"t","format":"html","description":"desc","acceptance_criteria":"ac","repro_steps":"steps","justification":"why"}"#,
         )
         .unwrap();
 
@@ -510,6 +539,12 @@ mod tests {
             if args.repro_steps.is_some() {
                 multiline_formats.push((
                     "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
                     "Markdown".to_string(),
                 ));
             }
@@ -540,6 +575,12 @@ mod tests {
             if args.repro_steps.is_some() {
                 multiline_formats.push((
                     "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
                     "Markdown".to_string(),
                 ));
             }

--- a/src/mcp/tools/work_items/update_work_item.rs
+++ b/src/mcp/tools/work_items/update_work_item.rs
@@ -22,7 +22,7 @@ pub struct UpdateWorkItemArgs {
     /// Work item ID to update
     pub id: u32,
 
-    /// Format for large text fields (description, acceptance criteria, repro steps): "markdown" or "html" (default: "markdown")
+    /// Format for large text fields (description, acceptance criteria, repro steps, justification): "markdown" or "html" (default: "markdown")
     #[serde(default = "default_text_format")]
     pub format: String,
 
@@ -102,6 +102,10 @@ pub struct UpdateWorkItemArgs {
     #[serde(default)]
     pub repro_steps: Option<String>,
 
+    /// Justification (CMMI process template; use markdown syntax when format is "markdown", HTML tags when format is "html")
+    #[serde(default)]
+    pub justification: Option<String>,
+
     /// Optional extra fields as JSON string (for custom fields)
     #[serde(default)]
     pub fields: Option<String>,
@@ -144,6 +148,12 @@ pub async fn update_work_item(
         if args.repro_steps.is_some() {
             multiline_formats.push((
                 "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                "Markdown".to_string(),
+            ));
+        }
+        if args.justification.is_some() {
+            multiline_formats.push((
+                "Microsoft.VSTS.CMMI.Justification".to_string(),
                 "Markdown".to_string(),
             ));
         }
@@ -246,6 +256,12 @@ pub async fn update_work_item(
         field_map.insert(
             "Microsoft.VSTS.TCM.ReproSteps".to_string(),
             serde_json::json!(repro_steps),
+        );
+    }
+    if let Some(justification) = &args.justification {
+        field_map.insert(
+            "Microsoft.VSTS.CMMI.Justification".to_string(),
+            serde_json::json!(justification),
         );
     }
 
@@ -381,7 +397,7 @@ mod tests {
     #[test]
     fn test_update_work_item_multiline_formats_built_for_markdown() {
         let args = deserialize_args(
-            r#"{"organization":"org","project":"proj","id":1,"description":"desc","acceptance_criteria":"ac","repro_steps":"steps"}"#,
+            r#"{"organization":"org","project":"proj","id":1,"description":"desc","acceptance_criteria":"ac","repro_steps":"steps","justification":"why"}"#,
         )
         .unwrap();
 
@@ -403,9 +419,15 @@ mod tests {
                     "Markdown".to_string(),
                 ));
             }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
         }
 
-        assert_eq!(multiline_formats.len(), 3);
+        assert_eq!(multiline_formats.len(), 4);
         assert_eq!(
             multiline_formats[0],
             ("System.Description".to_string(), "Markdown".to_string())
@@ -424,12 +446,19 @@ mod tests {
                 "Markdown".to_string()
             )
         );
+        assert_eq!(
+            multiline_formats[3],
+            (
+                "Microsoft.VSTS.CMMI.Justification".to_string(),
+                "Markdown".to_string()
+            )
+        );
     }
 
     #[test]
     fn test_update_work_item_multiline_formats_empty_for_html() {
         let args = deserialize_args(
-            r#"{"organization":"org","project":"proj","id":1,"format":"html","description":"desc","acceptance_criteria":"ac","repro_steps":"steps"}"#,
+            r#"{"organization":"org","project":"proj","id":1,"format":"html","description":"desc","acceptance_criteria":"ac","repro_steps":"steps","justification":"why"}"#,
         )
         .unwrap();
 
@@ -448,6 +477,12 @@ mod tests {
             if args.repro_steps.is_some() {
                 multiline_formats.push((
                     "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
                     "Markdown".to_string(),
                 ));
             }
@@ -478,6 +513,12 @@ mod tests {
             if args.repro_steps.is_some() {
                 multiline_formats.push((
                     "Microsoft.VSTS.TCM.ReproSteps".to_string(),
+                    "Markdown".to_string(),
+                ));
+            }
+            if args.justification.is_some() {
+                multiline_formats.push((
+                    "Microsoft.VSTS.CMMI.Justification".to_string(),
                     "Markdown".to_string(),
                 ));
             }

--- a/tests/test_tools_work_items.rs
+++ b/tests/test_tools_work_items.rs
@@ -107,6 +107,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )
@@ -147,6 +148,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )
@@ -357,6 +359,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )
@@ -397,6 +400,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )
@@ -708,6 +712,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )
@@ -753,6 +758,7 @@ mod tests {
                 target_date: None,
                 acceptance_criteria: None,
                 repro_steps: None,
+                justification: None,
                 fields: None,
             },
         )


### PR DESCRIPTION
## Summary

Adds `Microsoft.VSTS.CMMI.Justification` as a first-class large-text argument on the `azdo_create_work_item` and `azdo_update_work_item` MCP tools, mirroring the existing `description` / `acceptance_criteria` / `repro_steps` handling.

When `justification` is provided and `format` is `markdown`, the field is registered in the `multilineFieldsFormat` list so Azure DevOps stores it as Markdown; otherwise it is sent as a plain field value.

## Changes

- **`create_work_item.rs` / `update_work_item.rs`**
  - New `justification: Option<String>` arg (`#[serde(default)]`) with a doc comment.
  - `format` doc comment updated to mention justification.
  - `Microsoft.VSTS.CMMI.Justification` added to the markdown `multiline_formats` list (gated on `format == "markdown"` and the field being provided).
  - `Microsoft.VSTS.CMMI.Justification` inserted into the field map when provided.
  - Unit tests updated: markdown-present (asserts the new entry at index 3), html-empty, and only-provided-fields cases.
- **`tests/test_tools_work_items.rs`**: added `justification: None` to the six Args struct literals.

## Testing

- `make build` — clean (debug)
- `make release` — clean
- `make lint` (`cargo clippy --features test-support -- -D warnings`) — no warnings
- `make test` — 77 unit + all integration tests pass, 0 failures