### PR TITLE
fix(ci): build and release Linux x86_64 binaries

### DIFF
--- a/.github/workflows/cd-tag-build-and-release.yml
+++ b/.github/workflows/cd-tag-build-and-release.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-24.04
+            name: ubuntu-24.04-x86_64
           - os: ubuntu-24.04-arm
             name: ubuntu-24.04-aarch64
           - os: macos-latest
@@ -75,7 +77,17 @@ jobs:
       - name: List downloaded files (debug)
         run: ls -R dist
 
-      - name: Prepare Linux tar.gz
+      - name: Prepare Linux x86_64 tar.gz
+        run: |
+          set -eux
+          TAG="${GITHUB_REF_NAME}"
+          LINUX_DIR="dist/mcp-for-azure-devops-boards-ubuntu-24.04-x86_64"
+          cp "${LINUX_DIR}/mcp-for-azure-devops-boards-ubuntu-24.04-x86_64" mcp-for-azure-devops-boards
+          tar czf "mcp-for-azure-devops-boards-${TAG}-linux-x86_64.tar.gz" mcp-for-azure-devops-boards
+          rm mcp-for-azure-devops-boards
+          ls -l "mcp-for-azure-devops-boards-${TAG}-linux-x86_64.tar.gz"
+
+      - name: Prepare Linux aarch64 tar.gz
         run: |
           set -eux
           TAG="${GITHUB_REF_NAME}"
@@ -115,6 +127,7 @@ jobs:
           name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |
+            mcp-for-azure-devops-boards-${{ github.ref_name }}-linux-x86_64.tar.gz
             mcp-for-azure-devops-boards-${{ github.ref_name }}-linux-aarch64.tar.gz
             mcp-for-azure-devops-boards-${{ github.ref_name }}-macos-aarch64.tar.gz
             mcp-for-azure-devops-boards-${{ github.ref_name }}-windows-x86_64.zip

--- a/.github/workflows/ci-pr-build-and-test.yml
+++ b/.github/workflows/ci-pr-build-and-test.yml
@@ -24,6 +24,9 @@ jobs:
           - os-name: Linux-x86_64
             runs-on: ubuntu-latest
 
+          - os-name: Linux-aarch64
+            runs-on: ubuntu-24.04-arm
+
           - os-name: macOS-aarch64
             runs-on: macos-14
 


### PR DESCRIPTION
## Summary

The CD release workflow only built Linux **aarch64**, macOS aarch64, and Windows x86_64 — so **no Linux x86_64 package was ever published**, even though CI builds and tests that exact target. This adds Linux x86_64 to the release and aligns the PR matrix with the released architectures.

## Changes

**`cd-tag-build-and-release.yml`**
- Add `ubuntu-24.04` (x86_64) to the build matrix (`ubuntu-24.04-x86_64`), alongside the existing aarch64 entry.
- Add a `Prepare Linux x86_64 tar.gz` packaging step; rename the existing step to `Prepare Linux aarch64 tar.gz` for clarity.
- Add `...-linux-x86_64.tar.gz` to the release asset list.

Releases now ship: **linux-x86_64**, linux-aarch64, macos-aarch64, windows-x86_64.

**`ci-pr-build-and-test.yml`**
- Add a `Linux-aarch64` matrix entry (`ubuntu-24.04-arm`) so every architecture the CD workflow releases is also compiled and tested on PRs — closing the gap where released Linux aarch64 was never validated in CI.

## Note
The `Security Audit` CI job is currently red repo-wide due to unrelated pre-existing RUSTSEC advisories (`rmcp`, `astral-tokio-tar`); that is not introduced by this change and is tracked separately.