### PR TITLE
feat(app): add --allowed-host flag to configure HTTP Host allow-list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,13 @@ pub(crate) struct Args {
     /// Install MCP server configuration for the specified client
     #[arg(long, value_enum, conflicts_with = "server")]
     install: Option<InstallTarget>,
+
+    /// Allowed `Host` header value for the HTTP server (repeatable; only valid
+    /// with --server). When omitted, only loopback hosts (localhost, 127.0.0.1,
+    /// ::1) are accepted, which prevents DNS rebinding attacks. Provide your
+    /// deployment hostname(s) to serve behind a proxy or on a public interface.
+    #[arg(long = "allowed-host", value_name = "HOST", requires = "server")]
+    allowed_hosts: Vec<String>,
 }
 
 #[tokio::main]
@@ -44,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.server {
         let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", args.port)).await?;
         log::info!("Starting web server on {}", listener.local_addr()?);
-        http::run_server(mcp_server, listener).await?;
+        http::run_server(mcp_server, listener, args.allowed_hosts).await?;
     } else {
         log::info!("Starting stdio server");
         let service = mcp_server.serve(stdio()).await?;
@@ -85,6 +92,48 @@ mod tests {
         let args = Args::try_parse_from(["test", "--server", "--port", "8080"]).unwrap();
         assert!(args.server);
         assert_eq!(args.port, 8080);
+    }
+
+    #[test]
+    fn test_allowed_host_defaults_to_empty() {
+        let args = Args::try_parse_from(["test", "--server"]).unwrap();
+        assert!(
+            args.allowed_hosts.is_empty(),
+            "allowed_hosts must be empty by default so the loopback-only secure default applies"
+        );
+    }
+
+    #[test]
+    fn test_allowed_host_single() {
+        let args =
+            Args::try_parse_from(["test", "--server", "--allowed-host", "example.com"]).unwrap();
+        assert_eq!(args.allowed_hosts, vec!["example.com".to_string()]);
+    }
+
+    #[test]
+    fn test_allowed_host_repeatable() {
+        let args = Args::try_parse_from([
+            "test",
+            "--server",
+            "--allowed-host",
+            "example.com",
+            "--allowed-host",
+            "mcp.internal:8443",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.allowed_hosts,
+            vec!["example.com".to_string(), "mcp.internal:8443".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_allowed_host_requires_server() {
+        let result = Args::try_parse_from(["test", "--allowed-host", "example.com"]);
+        assert!(
+            result.is_err(),
+            "--allowed-host without --server must be rejected"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,12 +183,44 @@ mod tests {
     #[test]
     fn test_allowed_host_rejects_empty_value() {
         for value in ["", "   "] {
-            let result = Args::try_parse_from(["test", "--server", "--allowed-host", value]);
-            assert!(
-                result.is_err(),
-                "empty/whitespace --allowed-host '{value}' must be rejected so the loopback default is not replaced by a match-nothing list"
+            let err = Args::try_parse_from(["test", "--server", "--allowed-host", value])
+                .expect_err("empty/whitespace --allowed-host must be rejected");
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "empty/whitespace '{value}' must be rejected by the value parser so the loopback default is not replaced by a match-nothing list"
             );
         }
+    }
+
+    #[test]
+    fn test_allowed_host_trims_surrounding_whitespace() {
+        let args = Args::try_parse_from(["test", "--server", "--allowed-host", "  example.com  "])
+            .unwrap();
+        assert_eq!(
+            args.allowed_hosts,
+            vec!["example.com".to_string()],
+            "surrounding whitespace must be trimmed so it never reaches the allow-list"
+        );
+    }
+
+    #[test]
+    fn test_allowed_host_allows_duplicates() {
+        // Duplicates are accepted at parse time (rmcp deduplicates at match
+        // time via `.any()`); they must not be rejected as invalid.
+        let args = Args::try_parse_from([
+            "test",
+            "--server",
+            "--allowed-host",
+            "example.com",
+            "--allowed-host",
+            "example.com",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.allowed_hosts,
+            vec!["example.com".to_string(), "example.com".to_string()]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,30 @@ pub(crate) struct Args {
 
     /// Allowed `Host` header value for the HTTP server (repeatable; only valid
     /// with --server). When omitted, only loopback hosts (localhost, 127.0.0.1,
-    /// ::1) are accepted, which prevents DNS rebinding attacks. Provide your
-    /// deployment hostname(s) to serve behind a proxy or on a public interface.
-    #[arg(long = "allowed-host", value_name = "HOST", requires = "server")]
+    /// ::1) are accepted, which prevents DNS rebinding attacks. Providing any
+    /// value REPLACES the loopback default entirely, so loopback hosts must be
+    /// listed explicitly if they still need to be served (e.g. --allowed-host
+    /// mcp.example.com --allowed-host 127.0.0.1:3000).
+    #[arg(
+        long = "allowed-host",
+        value_name = "HOST",
+        requires = "server",
+        conflicts_with = "install",
+        value_parser = parse_allowed_host
+    )]
     allowed_hosts: Vec<String>,
+}
+
+/// Validates a single `--allowed-host` value. Rejects empty / whitespace-only
+/// input, which would otherwise replace the secure loopback default with an
+/// allow-list that matches no host and rejects every request. The trimmed value
+/// is returned so surrounding whitespace never reaches the allow-list.
+fn parse_allowed_host(value: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("allowed host must not be empty or whitespace-only".to_string());
+    }
+    Ok(trimmed.to_string())
 }
 
 #[tokio::main]
@@ -50,6 +70,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if args.server {
         let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", args.port)).await?;
+        log::warn!(
+            "HTTP server binds 0.0.0.0 and is unauthenticated. Host-header validation guards \
+             against DNS rebinding but is NOT network access control; deploy behind a firewall \
+             or reverse proxy."
+        );
         log::info!("Starting web server on {}", listener.local_addr()?);
         http::run_server(mcp_server, listener, args.allowed_hosts).await?;
     } else {
@@ -129,11 +154,41 @@ mod tests {
 
     #[test]
     fn test_allowed_host_requires_server() {
-        let result = Args::try_parse_from(["test", "--allowed-host", "example.com"]);
-        assert!(
-            result.is_err(),
-            "--allowed-host without --server must be rejected"
+        let err = Args::try_parse_from(["test", "--allowed-host", "example.com"])
+            .expect_err("--allowed-host without --server must be rejected");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "rejection must be due to the missing --server requirement"
         );
+        // The same value parses cleanly once --server is present.
+        Args::try_parse_from(["test", "--server", "--allowed-host", "example.com"])
+            .expect("--allowed-host with --server must parse");
+    }
+
+    #[test]
+    fn test_allowed_host_conflicts_with_install() {
+        // clap conflict rules take precedence over `requires`, so without an
+        // explicit conflict the flag would be silently accepted and ignored in
+        // install mode. Assert it is rejected instead.
+        let err = Args::try_parse_from(["test", "--install", "claude-code", "--allowed-host", "x"])
+            .expect_err("--allowed-host with --install must be rejected");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "rejection must be due to the --install conflict"
+        );
+    }
+
+    #[test]
+    fn test_allowed_host_rejects_empty_value() {
+        for value in ["", "   "] {
+            let result = Args::try_parse_from(["test", "--server", "--allowed-host", value]);
+            assert!(
+                result.is_err(),
+                "empty/whitespace --allowed-host '{value}' must be rejected so the loopback default is not replaced by a match-nothing list"
+            );
+        }
     }
 
     #[test]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -5,7 +5,7 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpService, session::local::LocalSessionManager,
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -15,11 +15,20 @@ const MAX_CONNECTIONS: usize = 256;
 pub async fn run_server(
     server: AzureMcpServer,
     listener: tokio::net::TcpListener,
+    allowed_hosts: Vec<String>,
 ) -> std::io::Result<()> {
+    // Preserve rmcp's secure default (loopback-only `Host` validation, which
+    // guards against DNS rebinding) unless the operator explicitly provides an
+    // allow-list, in which case it fully replaces the default.
+    let mut config = StreamableHttpServerConfig::default();
+    if !allowed_hosts.is_empty() {
+        config = config.with_allowed_hosts(allowed_hosts);
+    }
+
     let service = TowerToHyperService::new(StreamableHttpService::new(
         move || Ok(server.clone()),
         LocalSessionManager::default().into(),
-        Default::default(),
+        config,
     ));
 
     let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));

--- a/tests/test_server_http.rs
+++ b/tests/test_server_http.rs
@@ -13,7 +13,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let server_handle = tokio::spawn(async move {
-            let _ = http::run_server(server, listener).await;
+            let _ = http::run_server(server, listener, Vec::new()).await;
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -46,7 +46,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let server_handle = tokio::spawn(async move {
-            let _ = http::run_server(server, listener).await;
+            let _ = http::run_server(server, listener, Vec::new()).await;
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -76,7 +76,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let server_handle = tokio::spawn(async move {
-            let _ = http::run_server(server, listener).await;
+            let _ = http::run_server(server, listener, Vec::new()).await;
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -101,5 +101,83 @@ mod tests {
         );
 
         server_handle.abort();
+    }
+
+    // Spawns the HTTP server on an ephemeral loopback port with the given
+    // allowed-host list and returns its address. The listener is bound (and
+    // thus listening) before the accept task starts, so connections queue in
+    // the TCP backlog until it runs — no readiness sleep is required.
+    async fn spawn_server(allowed_hosts: Vec<String>) -> std::net::SocketAddr {
+        let server = AzureMcpServer::new_with_api(MockAzureDevOpsApi::new());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = http::run_server(server, listener, allowed_hosts).await;
+        });
+        addr
+    }
+
+    fn initialize_request(
+        client: &reqwest::Client,
+        addr: std::net::SocketAddr,
+        host: &str,
+    ) -> reqwest::RequestBuilder {
+        client
+            .post(format!("http://{}/mcp", addr))
+            .header(reqwest::header::HOST, host)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}"#)
+    }
+
+    #[tokio::test]
+    async fn test_allowed_host_permits_configured_and_rejects_others() {
+        let addr = spawn_server(vec!["example.com".to_string()]).await;
+        let client = reqwest::Client::new();
+
+        // A request whose Host matches the configured allow-list passes
+        // DNS-rebinding validation and reaches MCP handling (not 403).
+        let allowed = initialize_request(&client, addr, "example.com")
+            .send()
+            .await
+            .unwrap();
+        assert_ne!(
+            allowed.status().as_u16(),
+            403,
+            "configured Host 'example.com' must be accepted, got {}",
+            allowed.status()
+        );
+
+        // A request with a Host outside the allow-list is rejected, even though
+        // the underlying socket is the loopback address it connected to.
+        let rejected = initialize_request(&client, addr, "attacker.example")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            rejected.status().as_u16(),
+            403,
+            "Host outside the allow-list must be rejected with 403, got {}",
+            rejected.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_rejects_non_loopback_host() {
+        // With no allow-list the rmcp secure default permits only loopback
+        // hosts, so a non-loopback Host must be rejected with 403.
+        let addr = spawn_server(Vec::new()).await;
+        let client = reqwest::Client::new();
+
+        let rejected = initialize_request(&client, addr, "attacker.example")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            rejected.status().as_u16(),
+            403,
+            "non-loopback Host must be rejected by the loopback-only default, got {}",
+            rejected.status()
+        );
     }
 }

--- a/tests/test_server_http.rs
+++ b/tests/test_server_http.rs
@@ -148,6 +148,17 @@ mod tests {
             allowed.status()
         );
 
+        // Host matching is case-insensitive (rmcp lowercases before comparing).
+        let allowed_upper = initialize_request(&client, addr, "EXAMPLE.COM")
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            allowed_upper.status().is_success(),
+            "Host matching must be case-insensitive; 'EXAMPLE.COM' must be accepted, got {}",
+            allowed_upper.status()
+        );
+
         // A request with a Host outside the allow-list is rejected, even though
         // the underlying socket is the loopback address it connected to.
         let rejected = initialize_request(&client, addr, "attacker.example")
@@ -179,6 +190,26 @@ mod tests {
             "non-loopback Host must be rejected by the loopback-only default, got {}",
             rejected.status()
         );
+    }
+
+    #[tokio::test]
+    async fn test_default_accepts_loopback_hosts() {
+        // The positive half of the secure default: with no allow-list, the
+        // loopback hosts rmcp permits by default are accepted.
+        let addr = spawn_server(Vec::new()).await;
+        let client = reqwest::Client::new();
+
+        for host in ["localhost", "127.0.0.1", "[::1]"] {
+            let accepted = initialize_request(&client, addr, host)
+                .send()
+                .await
+                .unwrap();
+            assert!(
+                accepted.status().is_success(),
+                "loopback Host '{host}' must be accepted under the default, got {}",
+                accepted.status()
+            );
+        }
     }
 
     #[tokio::test]
@@ -228,5 +259,28 @@ mod tests {
             "loopback must be rejected once the allow-list replaces the default, got {}",
             loopback.status()
         );
+
+        // A port-less allow entry ("a.example") matches the host on ANY port.
+        let any_port = initialize_request(&client, addr, "a.example:8080")
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            any_port.status().is_success(),
+            "port-less allow entry must match any port; 'a.example:8080' expected 2xx, got {}",
+            any_port.status()
+        );
+
+        // A port-scoped allow entry ("mcp.internal:8443") requires an exact
+        // port match: a mismatched port and a port-less Host are both rejected.
+        for bad in ["mcp.internal:9999", "mcp.internal"] {
+            let response = initialize_request(&client, addr, bad).send().await.unwrap();
+            assert_eq!(
+                response.status().as_u16(),
+                403,
+                "port-scoped entry must reject a mismatched/absent port; '{bad}' expected 403, got {}",
+                response.status()
+            );
+        }
     }
 }

--- a/tests/test_server_http.rs
+++ b/tests/test_server_http.rs
@@ -136,15 +136,15 @@ mod tests {
         let client = reqwest::Client::new();
 
         // A request whose Host matches the configured allow-list passes
-        // DNS-rebinding validation and reaches MCP handling (not 403).
+        // DNS-rebinding validation and reaches MCP handling (a 2xx response,
+        // not the 403 that a rejected Host would produce).
         let allowed = initialize_request(&client, addr, "example.com")
             .send()
             .await
             .unwrap();
-        assert_ne!(
-            allowed.status().as_u16(),
-            403,
-            "configured Host 'example.com' must be accepted, got {}",
+        assert!(
+            allowed.status().is_success(),
+            "configured Host 'example.com' must be accepted and reach MCP handling (2xx), got {}",
             allowed.status()
         );
 
@@ -178,6 +178,55 @@ mod tests {
             403,
             "non-loopback Host must be rejected by the loopback-only default, got {}",
             rejected.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_allowed_hosts_multiple_entries_replace_default() {
+        // A multi-entry allow-list (including a host:port entry) fully replaces
+        // the loopback default: every configured host is accepted, an unlisted
+        // host is rejected, and loopback (no longer listed) is rejected too.
+        let addr = spawn_server(vec![
+            "a.example".to_string(),
+            "b.example".to_string(),
+            "mcp.internal:8443".to_string(),
+        ])
+        .await;
+        let client = reqwest::Client::new();
+
+        for host in ["a.example", "b.example", "mcp.internal:8443"] {
+            let response = initialize_request(&client, addr, host)
+                .send()
+                .await
+                .unwrap();
+            assert!(
+                response.status().is_success(),
+                "configured host '{host}' must be accepted, got {}",
+                response.status()
+            );
+        }
+
+        let unlisted = initialize_request(&client, addr, "attacker.example")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            unlisted.status().as_u16(),
+            403,
+            "unlisted host must be rejected with 403, got {}",
+            unlisted.status()
+        );
+
+        // The loopback default was replaced, so 127.0.0.1 is no longer allowed.
+        let loopback = initialize_request(&client, addr, "127.0.0.1")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            loopback.status().as_u16(),
+            403,
+            "loopback must be rejected once the allow-list replaces the default, got {}",
+            loopback.status()
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds a `--allowed-host` CLI flag so `--server` (HTTP) deployments can run behind a reverse proxy or on a public hostname while keeping the rmcp DNS-rebinding protection intact.

Background: rmcp 2.1.0 enforces **loopback-only `Host`-header validation by default** (the fix for RUSTSEC-2026-0189 / CVE-2026-42559). That default rejects requests reaching the server via any non-loopback hostname, which breaks legitimate proxied/public `--server` deployments. This flag lets operators authorize their own hostnames without disabling the protection.

## Behavior

- `--allowed-host <HOST>` — repeatable; populates `StreamableHttpServerConfig.allowed_hosts`.
- **Omitted** → rmcp's secure loopback-only default is preserved (`localhost`, `127.0.0.1`, `::1`).
- **Provided** → the value(s) **replace** the loopback default entirely (rmcp `with_allowed_hosts` semantics); include loopback hosts explicitly if still needed. Documented in the help text.
- `requires = "server"` (rejected without `--server`) and `conflicts_with = "install"` (rejected alongside `--install`).
- Empty/whitespace-only values are rejected at parse time (would otherwise replace the default with a match-nothing list and silently 403 every request).
- The security control is **never disabled** — there is no path that produces an empty (allow-all) list.
- A startup `log::warn!` notes that Host validation is not network access control on the `0.0.0.0` bind (deploy behind a firewall/reverse proxy).

## Tests

- **Unit (flag parsing):** default empty; single; repeatable; `requires`-server (asserts `MissingRequiredArgument`); `conflicts_with` install (asserts `ArgumentConflict`); empty/whitespace rejected (asserts `ValueValidation`); surrounding-whitespace trimmed; duplicates accepted.
- **Integration (end-to-end server behavior):** configured Host accepted (2xx) incl. case-insensitive; unlisted Host → 403; loopback-only default rejects non-loopback and accepts `localhost`/`127.0.0.1`/`[::1]`; multi-entry allow-list replaces the default (each entry accepted, unlisted + loopback → 403); rmcp port semantics (port-less entry matches any port; port-scoped entry rejects mismatched/absent port).

## Review

Reviewed with the `code-reviewer` agent plus a 3-lens adversarial panel (security / correctness / test-validity). All findings were addressed across the `fix(app)` and `test(app)` commits; the final re-review is clean on all three lenses.

## Verification

`cargo fmt --check` · `cargo clippy --features test-support -- -D warnings` · `cargo test --features test-support` (all pass) · `cargo build --release` — all green. CLI smoke: `--help` documents the flag; invalid combinations error without side effects.
