### PR TITLE
chore(deps): bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-for-azure-devops-boards"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "mcp-tools-codegen"]
 
 [package]
 name = "mcp-for-azure-devops-boards"
-version = "0.7.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["Daniele Salvatore Albano <d.albano@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumps the crate version `0.7.0` → `1.0.0` in preparation for the **v1.0.0** release.

Once merged, tag `v1.0.0` on `main` to trigger the CD build-and-release workflow (draft release with cross-platform binaries).

`cargo build --release --locked` verified locally.